### PR TITLE
feat: email ingestion pipeline — BCP, Interbank, BBVA, Scotiabank, Yape/Plin

### DIFF
--- a/.specs/4-feature/tasks.md
+++ b/.specs/4-feature/tasks.md
@@ -1,0 +1,375 @@
+# Tasks — Email Ingestion Pipeline
+
+## Issue: #4 — BCP, Interbank, BBVA, Scotiabank, Yape/Plin
+## Version: v1.0
+## Date: 2026-04-04
+## Status: In Progress
+
+---
+
+## Resumen de dependencias
+
+```
+T-01 (config.gs)
+T-02 (utils.gs)
+  └── T-03 (gmail-service.gs) → depende de T-01, T-02
+  └── T-04 (sheets-service.gs) → depende de T-01, T-02
+  └── T-05 (claude-service.gs) → depende de T-01, T-02
+T-06..T-11 (parsers) → independientes entre sí, dependen de T-02
+T-12 (main.gs) → depende de T-01..T-11
+T-13 (appsscript.json) → independiente
+T-14 (tests) → depende de T-01..T-12
+```
+
+---
+
+## T-01 — `src/config.gs` — Configuración central
+
+**Prioridad:** Alta  
+**Dependencias:** Ninguna  
+**Estimación:** 30 min
+
+### Descripción
+
+Crear el objeto `CONFIG` con todos los parámetros configurables del pipeline:
+- `spreadsheetId`, `sheetName`, `usuario`
+- `claudeApiKey` (leído de `PropertiesService`)
+- `bancos`: objeto con configuración por banco (BCP, Interbank, BBVA, Scotiabank, Yape, Plin)
+- `execution`: parámetros de checkpoint y timeout
+
+### Criterios de aceptación
+
+- [ ] `CONFIG` exportable como constante global accesible desde todos los módulos
+- [ ] Clave API leída de `PropertiesService`, no hardcodeada
+- [ ] Un banco puede deshabilitarse con `enabled: false` sin tocar otro código
+- [ ] Parámetros de `gmail_query`, `label_procesado`, `label_error`, `fallback_ai`, `banco_nombre` presentes por banco
+
+---
+
+## T-02 — `src/utils.gs` — Utilidades
+
+**Prioridad:** Alta  
+**Dependencias:** Ninguna  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar funciones helper reutilizables:
+- `parseDate(str)` → `string YYYY-MM-DD | null`
+- `parseAmount(str)` → `number | null`
+- `normalizeText(str)` → `string`
+- `sanitizeForPrompt(str)` → `string` (remueve control chars)
+- `log(level, message, data)` → void
+- `getNowLima()` → `string` ISO 8601 UTC-5
+- `getOrCreateLabel(labelName)` → Gmail label
+
+### Criterios de aceptación
+
+- [ ] `parseDate` soporta formatos DD/MM/YYYY, DD-MM-YYYY, YYYY-MM-DD, "15 de enero de 2026"
+- [ ] `parseAmount` maneja separadores peruanos: "1,234.56" y "1.234,56"
+- [ ] `sanitizeForPrompt` elimina caracteres de control y trunca a 3000 chars
+- [ ] `log` nunca registra el cuerpo completo del email, solo asunto y email_id
+
+---
+
+## T-03 — `src/gmail-service.gs` — Servicio Gmail
+
+**Prioridad:** Alta  
+**Dependencias:** T-01, T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `GmailService` con métodos:
+- `searchEmails(query)` → `GmailMessage[]`
+- `getEmailBody(message)` → `string` (plain text, fallback HTML→text)
+- `applyLabel(message, labelName)` → void
+- `buildQuery(bankConfig)` → `string` (query con exclusión de labels procesados)
+
+### Criterios de aceptación
+
+- [ ] `buildQuery` añade `-label:<ok> -label:<error>` automáticamente
+- [ ] `getEmailBody` retorna texto plano; si no hay, extrae texto de HTML
+- [ ] `applyLabel` crea el label si no existe usando `getOrCreateLabel`
+- [ ] Maneja threads con múltiples mensajes (usa el primer mensaje)
+
+---
+
+## T-04 — `src/sheets-service.gs` — Servicio Sheets
+
+**Prioridad:** Alta  
+**Dependencias:** T-01, T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `SheetsService` con métodos:
+- `getProcessedEmailIds()` → `Set<string>`
+- `appendRow(row)` → void
+- `ensureHeaders()` → void (crea header row si la hoja está vacía)
+
+### Criterios de aceptación
+
+- [ ] `getProcessedEmailIds` lee la columna J (email_id) completa al inicio
+- [ ] `appendRow` escribe las 11 columnas en el orden definido en requirements.md
+- [ ] `ensureHeaders` crea headers si la hoja está vacía
+- [ ] Maneja el caso de Sheets no encontrado con error descriptivo
+
+---
+
+## T-05 — `src/claude-service.gs` — Servicio Claude API
+
+**Prioridad:** Alta  
+**Dependencias:** T-01, T-02  
+**Estimación:** 60 min
+
+### Descripción
+
+Implementar `ClaudeService` con dos métodos:
+- `categorize(comercio, monto, banco)` → `string` (categoría de la lista)
+- `parseWithAI(emailBody, banco)` → `{fecha, monto, comercio} | null`
+
+Usar `UrlFetchApp.fetch()` para llamar a Claude API con `claude-haiku-4-5`.
+
+### Criterios de aceptación
+
+- [ ] `categorize` retorna una de las 12 categorías válidas o "Otro" como fallback
+- [ ] `parseWithAI` retorna `null` si la respuesta no tiene JSON válido
+- [ ] Maneja errores HTTP de Claude API (4xx, 5xx) retornando null sin tirar excepción
+- [ ] Prompt de categorización incluye comercio, monto y banco
+- [ ] Prompt de parseo incluye cuerpo del email sanitizado (max 3000 chars)
+- [ ] Timeout de 30s para ambas llamadas via `muteHttpExceptions: true`
+
+---
+
+## T-06 — `src/parsers/bcp-parser.gs` — Parser BCP
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 60 min
+
+### Descripción
+
+Implementar `BcpParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico BCP:
+- Asunto: "Consumo con tu tarjeta BCP"
+- Monto: "S/ 150.00" o "USD 25.00"
+- Fecha: "15/01/2026" o "15 de enero de 2026"
+- Comercio: "WONG LAS BEGONIAS" o similar
+
+### Criterios de aceptación
+
+- [ ] Extrae monto, fecha y comercio de email típico BCP
+- [ ] Retorna `null` si no puede extraer monto o fecha
+- [ ] `raw` contiene el cuerpo original para debugging
+- [ ] Testeable con fixture de email BCP
+
+---
+
+## T-07 — `src/parsers/interbank-parser.gs` — Parser Interbank
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `InterbankParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico Interbank:
+- Alerta de consumo con tarjeta
+- Monto en soles o dólares
+- Nombre del establecimiento
+
+### Criterios de aceptación
+
+- [ ] Extrae los 3 campos de email típico Interbank
+- [ ] Retorna `null` si faltan campos obligatorios
+
+---
+
+## T-08 — `src/parsers/bbva-parser.gs` — Parser BBVA
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `BbvaParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico BBVA:
+- "Alerta de compra" con monto y establecimiento
+- Fecha de la transacción incluida
+
+### Criterios de aceptación
+
+- [ ] Extrae los 3 campos de email típico BBVA
+- [ ] Retorna `null` si faltan campos obligatorios
+
+---
+
+## T-09 — `src/parsers/scotiabank-parser.gs` — Parser Scotiabank
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `ScotiabankParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico Scotiabank:
+- Notificación de consumo con tarjeta
+- Monto, fecha, establecimiento
+
+### Criterios de aceptación
+
+- [ ] Extrae los 3 campos de email típico Scotiabank
+- [ ] Retorna `null` si faltan campos obligatorios
+
+---
+
+## T-10 — `src/parsers/yape-parser.gs` — Parser Yape
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 45 min
+
+### Descripción
+
+Implementar `YapeParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico Yape:
+- "Realizaste un pago a [nombre]"
+- Monto en soles
+- Fecha de la operación
+
+### Criterios de aceptación
+
+- [ ] Extrae monto, fecha y nombre del destinatario como comercio
+- [ ] Retorna `null` si faltan campos obligatorios
+
+---
+
+## T-11 — `src/parsers/plin-parser.gs` — Parser Plin
+
+**Prioridad:** Media  
+**Dependencias:** T-02  
+**Estimación:** 30 min
+
+### Descripción
+
+Implementar `PlinParser` con método `parse(body)` → `ParsedEmail | null`.
+
+Formato típico Plin:
+- Confirmación de pago enviado
+- Monto en soles
+- Nombre del destinatario
+
+### Criterios de aceptación
+
+- [ ] Extrae monto, fecha y nombre del destinatario como comercio
+- [ ] Retorna `null` si faltan campos obligatorios
+
+---
+
+## T-12 — `src/main.gs` — Orquestador principal
+
+**Prioridad:** Alta  
+**Dependencias:** T-01..T-11  
+**Estimación:** 60 min
+
+### Descripción
+
+Implementar `main()` (entry point del trigger diario) y `ParserRegistry`:
+
+```
+main()
+  ├── SheetsService.getProcessedEmailIds()
+  ├── para cada banco habilitado en CONFIG:
+  │   ├── GmailService.searchEmails(query)
+  │   └── para cada email:
+  │       ├── skip si email_id ya procesado
+  │       ├── ParserRegistry.getParser(banco).parse(body)
+  │       ├── si parse ok → ClaudeService.categorize()
+  │       ├── si parse fail y fallback_ai → ClaudeService.parseWithAI()
+  │       ├── SheetsService.appendRow(row)
+  │       └── GmailService.applyLabel()
+  └── log resumen
+```
+
+Implementar checkpoint anti-timeout (DT-007): si `Date.now() - startTime > 5.5min`, guardar progreso en PropertiesService y salir.
+
+### Criterios de aceptación
+
+- [ ] `main()` puede ser llamada desde trigger diario de Apps Script
+- [ ] `ParserRegistry` mapea banco → parser correctamente
+- [ ] Fail-open: un email con error no interrumpe el pipeline (DT-006)
+- [ ] Checkpoint guardado si tiempo > 5.5 minutos
+- [ ] Log final con conteo: procesados, errores, omitidos por dedup, tiempo total
+
+---
+
+## T-13 — `appsscript.json` — Manifest
+
+**Prioridad:** Alta  
+**Dependencias:** Ninguna  
+**Estimación:** 15 min
+
+### Descripción
+
+Crear manifest de Apps Script con:
+- Scopes OAuth: `gmail.modify`, `spreadsheets`, `script.external_request`
+- `timeZone`: `America/Lima`
+- `exceptionLogging`: `STACKDRIVER`
+
+### Criterios de aceptación
+
+- [ ] Todos los scopes OAuth requeridos incluidos
+- [ ] Timezone configurado como `America/Lima`
+- [ ] Logging habilitado para diagnóstico
+
+---
+
+## T-14 — Tests unitarios
+
+**Prioridad:** Media  
+**Dependencias:** T-01..T-12  
+**Estimación:** 90 min
+
+### Descripción
+
+Crear `tests/` con tests para cada componente usando un framework simple de mocking en GAS:
+
+- `tests/test-runner.gs` — framework de tests simple (assert, mock)
+- `tests/utils-test.gs` — tests para `utils.gs`
+- `tests/parsers-test.gs` — tests para los 6 parsers con fixtures
+- `tests/claude-service-test.gs` — tests para `ClaudeService` con mocks de UrlFetchApp
+- `tests/sheets-service-test.gs` — tests para `SheetsService` con mocks de SpreadsheetApp
+- `tests/gmail-service-test.gs` — tests para `GmailService` con mocks de GmailApp
+- `tests/main-test.gs` — tests de integración del orquestador
+
+### Criterios de aceptación
+
+- [ ] Cada parser tiene al menos 2 tests: parse exitoso y parse fallido (null)
+- [ ] `ClaudeService` tiene tests con mock de `UrlFetchApp` (sin llamadas reales)
+- [ ] `SheetsService.getProcessedEmailIds()` tiene test de deduplicación
+- [ ] Todos los tests pasan al ejecutar `runAllTests()` en Apps Script
+
+---
+
+## Orden de implementación recomendado
+
+```
+1. T-13 appsscript.json       (independiente, rápido)
+2. T-01 config.gs             (base de todo)
+3. T-02 utils.gs              (dependen los servicios)
+4. T-06..T-11 parsers         (paralelo, independientes)
+5. T-03 gmail-service.gs      (depende de T-01, T-02)
+6. T-04 sheets-service.gs     (depende de T-01, T-02)
+7. T-05 claude-service.gs     (depende de T-01, T-02)
+8. T-12 main.gs               (integra todo)
+9. T-14 tests                 (valida todo)
+```

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,12 @@
+{
+  "timeZone": "America/Lima",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ]
+}

--- a/src/claude-service.gs
+++ b/src/claude-service.gs
@@ -1,0 +1,132 @@
+/**
+ * claude-service.gs — Cliente de Claude API para categorización y parseo fallback
+ */
+
+const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
+const CLAUDE_API_VERSION = '2023-06-01';
+const CLAUDE_TIMEOUT_MS = 30000;
+
+const ClaudeService = {
+  /**
+   * Llama a Claude API con el prompt dado.
+   * @param {string} prompt
+   * @returns {string|null} Respuesta de texto o null si hubo error
+   */
+  _call(prompt) {
+    const apiKey = CONFIG.claudeApiKey;
+    if (!apiKey) {
+      log('ERROR', 'CLAUDE_API_KEY no configurada en PropertiesService');
+      return null;
+    }
+
+    const payload = {
+      model: CONFIG.claudeModel,
+      max_tokens: 256,
+      messages: [{ role: 'user', content: prompt }]
+    };
+
+    const options = {
+      method: 'post',
+      contentType: 'application/json',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': CLAUDE_API_VERSION
+      },
+      payload: JSON.stringify(payload),
+      muteHttpExceptions: true,
+      timeout: CLAUDE_TIMEOUT_MS
+    };
+
+    try {
+      const response = UrlFetchApp.fetch(CLAUDE_API_URL, options);
+      const code = response.getResponseCode();
+
+      if (code !== 200) {
+        log('WARN', 'Claude API error HTTP', { status: code });
+        return null;
+      }
+
+      const body = JSON.parse(response.getContentText());
+      const text = body?.content?.[0]?.text;
+      return text ? text.trim() : null;
+    } catch (e) {
+      log('ERROR', 'Error llamando Claude API', { error: e.message });
+      return null;
+    }
+  },
+
+  /**
+   * Categoriza un gasto usando Claude API.
+   * @param {string} comercio - Nombre del comercio
+   * @param {number} monto - Monto en soles
+   * @param {string} banco - Nombre del banco
+   * @returns {{categoria: string, categorized_by_ai: boolean}}
+   */
+  categorize(comercio, monto, banco) {
+    const categorias = CONFIG.categorias.join(', ');
+    const prompt =
+      `Clasifica este gasto en una sola categoría de la lista.\n` +
+      `Comercio: ${comercio}\n` +
+      `Monto: S/ ${monto}\n` +
+      `Banco: ${banco}\n` +
+      `Categorías válidas: ${categorias}\n` +
+      `Responde SOLO con el nombre de la categoría, sin explicación.`;
+
+    const response = this._call(prompt);
+
+    if (!response) {
+      return { categoria: 'Sin categorizar', categorized_by_ai: false };
+    }
+
+    // Validar que la respuesta es una categoría válida
+    const categoriaLimpia = response.split('\n')[0].trim();
+    const esValida = CONFIG.categorias.some(
+      (c) => c.toLowerCase() === categoriaLimpia.toLowerCase()
+    );
+
+    const categoria = esValida ? categoriaLimpia : 'Otro';
+    return { categoria, categorized_by_ai: true };
+  },
+
+  /**
+   * Intenta parsear un email con Claude API como fallback.
+   * @param {string} emailBody - Cuerpo del email
+   * @param {string} banco - Nombre del banco para contexto
+   * @returns {{fecha: string, monto: number, comercio: string, parsed_by_ai: boolean}|null}
+   */
+  parseWithAI(emailBody, banco) {
+    const safeBody = sanitizeForPrompt(emailBody);
+    const prompt =
+      `Extrae los datos de gasto de este email bancario peruano.\n` +
+      `Banco: ${banco}\n` +
+      `Email:\n${safeBody}\n\n` +
+      `Responde en JSON con exactamente estos campos:\n` +
+      `{"fecha": "YYYY-MM-DD", "monto": number, "comercio": "string"}\n` +
+      `Si no puedes extraer algún campo, responde null como valor del campo.\n` +
+      `Responde SOLO el JSON, sin texto adicional.`;
+
+    const response = this._call(prompt);
+
+    if (!response) return null;
+
+    try {
+      // Extraer JSON de la respuesta (puede haber texto antes/después)
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) return null;
+
+      const parsed = JSON.parse(jsonMatch[0]);
+
+      if (!parsed.monto || !parsed.fecha) return null;
+
+      return {
+        fecha: parseDate(parsed.fecha) || parsed.fecha,
+        monto: parseAmount(String(parsed.monto)) || parsed.monto,
+        comercio: normalizeText(parsed.comercio || 'Desconocido'),
+        parsed_by_ai: true
+      };
+    } catch (e) {
+      log('WARN', 'No se pudo parsear respuesta JSON de Claude', { error: e.message });
+      return null;
+    }
+  }
+};

--- a/src/config.gs
+++ b/src/config.gs
@@ -1,0 +1,110 @@
+/**
+ * config.gs — Configuración central del pipeline de ingesta de emails
+ *
+ * INSTRUCCIONES DE SETUP:
+ * 1. Reemplazar SHEET_ID_AQUI con el ID de tu Google Sheet
+ * 2. Configurar CLAUDE_API_KEY en Apps Script:
+ *    Menu > Project Settings > Script Properties > Add property
+ *    Key: CLAUDE_API_KEY, Value: sk-ant-...
+ * 3. Cambiar CONFIG.usuario a "usuario2" en la segunda instancia del script
+ */
+
+const CONFIG = {
+  // ID del Google Sheet (obtenido de la URL: /spreadsheets/d/<ID>/edit)
+  spreadsheetId: 'SHEET_ID_AQUI',
+
+  // Nombre de la hoja donde se registran los gastos
+  sheetName: 'gastos',
+
+  // Identificador del usuario para esta instancia del script
+  // Cambiar a "usuario2" en la segunda instancia
+  usuario: 'usuario1',
+
+  // Clave API de Claude — leída de PropertiesService, nunca hardcodeada
+  get claudeApiKey() {
+    return PropertiesService.getScriptProperties().getProperty('CLAUDE_API_KEY');
+  },
+
+  // Modelo de Claude a usar
+  claudeModel: 'claude-haiku-4-5-20251001',
+
+  // Máximo de caracteres del cuerpo del email enviado a Claude
+  maxEmailBodyChars: 3000,
+
+  // Tiempo máximo de ejecución en ms antes de guardar checkpoint (5.5 min)
+  maxExecutionMs: 330000,
+
+  // Configuración por banco
+  bancos: {
+    bcp: {
+      enabled: true,
+      banco_nombre: 'BCP',
+      gmail_query: 'from:(alertas@notificacionesbcp.com.pe) subject:(consumo OR cargo)',
+      label_procesado: 'ingesta/bcp/ok',
+      label_error: 'ingesta/bcp/error',
+      parser: 'bcp',
+      fallback_ai: true
+    },
+    interbank: {
+      enabled: true,
+      banco_nombre: 'Interbank',
+      gmail_query: 'from:(alertas@interbank.pe) subject:(consumo OR cargo)',
+      label_procesado: 'ingesta/interbank/ok',
+      label_error: 'ingesta/interbank/error',
+      parser: 'interbank',
+      fallback_ai: true
+    },
+    bbva: {
+      enabled: true,
+      banco_nombre: 'BBVA',
+      gmail_query: 'from:(alertas@notificaciones.bbvaperu.com) subject:(alerta OR compra)',
+      label_procesado: 'ingesta/bbva/ok',
+      label_error: 'ingesta/bbva/error',
+      parser: 'bbva',
+      fallback_ai: true
+    },
+    scotiabank: {
+      enabled: true,
+      banco_nombre: 'Scotiabank',
+      gmail_query: 'from:(notificaciones@scotiabank.com.pe)',
+      label_procesado: 'ingesta/scotiabank/ok',
+      label_error: 'ingesta/scotiabank/error',
+      parser: 'scotiabank',
+      fallback_ai: true
+    },
+    yape: {
+      enabled: true,
+      banco_nombre: 'Yape',
+      gmail_query: 'from:(noreply@yape.com.pe) subject:(realizaste un pago)',
+      label_procesado: 'ingesta/yape/ok',
+      label_error: 'ingesta/yape/error',
+      parser: 'yape',
+      fallback_ai: false
+    },
+    plin: {
+      enabled: true,
+      banco_nombre: 'Plin',
+      gmail_query: 'from:(noreply@plin.pe) subject:(realizaste un pago)',
+      label_procesado: 'ingesta/plin/ok',
+      label_error: 'ingesta/plin/error',
+      parser: 'plin',
+      fallback_ai: false
+    }
+  },
+
+  // Categorías válidas para clasificación
+  categorias: [
+    'Supermercado',
+    'Restaurante',
+    'Transporte',
+    'Salud',
+    'Educación',
+    'Entretenimiento',
+    'Ropa',
+    'Tecnología',
+    'Hogar',
+    'Servicios',
+    'Transferencia',
+    'Otro'
+  ]
+};

--- a/src/config.gs
+++ b/src/config.gs
@@ -57,7 +57,7 @@ const CONFIG = {
     bbva: {
       enabled: true,
       banco_nombre: 'BBVA',
-      gmail_query: 'from:(alertas@notificaciones.bbvaperu.com) subject:(alerta OR compra)',
+      gmail_query: 'from:(procesos@bbva.com.pe) subject:(Compras OR Consumo)',
       label_procesado: 'ingesta/bbva/ok',
       label_error: 'ingesta/bbva/error',
       parser: 'bbva',
@@ -66,10 +66,19 @@ const CONFIG = {
     scotiabank: {
       enabled: true,
       banco_nombre: 'Scotiabank',
-      gmail_query: 'from:(notificaciones@scotiabank.com.pe)',
+      gmail_query: 'from:(alertas@scotiabank.com.pe) subject:(Compras OR Consumo)',
       label_procesado: 'ingesta/scotiabank/ok',
       label_error: 'ingesta/scotiabank/error',
       parser: 'scotiabank',
+      fallback_ai: true
+    },
+    diners: {
+      enabled: true,
+      banco_nombre: 'Diners Club',
+      gmail_query: 'from:(avisos@dinersenlinea.pe) subject:(Compras OR Consumo)',
+      label_procesado: 'ingesta/diners/ok',
+      label_error: 'ingesta/diners/error',
+      parser: 'diners',
       fallback_ai: true
     },
     yape: {

--- a/src/gmail-service.gs
+++ b/src/gmail-service.gs
@@ -1,0 +1,106 @@
+/**
+ * gmail-service.gs — Abstracción sobre GmailApp para búsqueda y etiquetado
+ */
+
+const GmailService = {
+  /**
+   * Construye la query de búsqueda incluyendo exclusión de labels ya procesados.
+   * @param {Object} bankConfig - Configuración del banco desde CONFIG.bancos
+   * @returns {string}
+   */
+  buildQuery(bankConfig) {
+    const exclusions = [
+      `-label:${bankConfig.label_procesado}`,
+      `-label:${bankConfig.label_error}`
+    ].join(' ');
+    return `${bankConfig.gmail_query} ${exclusions}`;
+  },
+
+  /**
+   * Busca emails no procesados para un banco dado.
+   * @param {Object} bankConfig
+   * @returns {GmailMessage[]}
+   */
+  searchEmails(bankConfig) {
+    const query = this.buildQuery(bankConfig);
+    log('INFO', 'Buscando emails', { banco: bankConfig.banco_nombre, query });
+
+    try {
+      const threads = GmailApp.search(query, 0, 50);
+      const messages = [];
+
+      for (const thread of threads) {
+        const msgs = thread.getMessages();
+        if (msgs.length > 0) {
+          messages.push(msgs[0]);
+        }
+      }
+
+      log('INFO', 'Emails encontrados', { banco: bankConfig.banco_nombre, count: messages.length });
+      return messages;
+    } catch (e) {
+      log('ERROR', 'Error buscando emails', { banco: bankConfig.banco_nombre, error: e.message });
+      return [];
+    }
+  },
+
+  /**
+   * Obtiene el cuerpo del email en texto plano.
+   * Usa el cuerpo plain text si está disponible, sino convierte HTML.
+   * @param {GmailMessage} message
+   * @returns {string}
+   */
+  getEmailBody(message) {
+    try {
+      const plainBody = message.getPlainBody();
+      if (plainBody && plainBody.trim().length > 0) {
+        return plainBody;
+      }
+      // Fallback: convertir HTML a texto
+      const htmlBody = message.getBody();
+      return htmlToText(htmlBody);
+    } catch (e) {
+      log('WARN', 'Error obteniendo cuerpo del email', {
+        emailId: message.getId(),
+        error: e.message
+      });
+      return '';
+    }
+  },
+
+  /**
+   * Aplica un label de Gmail al email. Crea el label si no existe.
+   * @param {GmailMessage} message
+   * @param {string} labelName
+   */
+  applyLabel(message, labelName) {
+    try {
+      const label = getOrCreateLabel(labelName);
+      message.getThread().addLabel(label);
+    } catch (e) {
+      log('ERROR', 'Error aplicando label', {
+        emailId: message.getId(),
+        label: labelName,
+        error: e.message
+      });
+    }
+  },
+
+  /**
+   * Retorna el ID único del mensaje de Gmail.
+   * @param {GmailMessage} message
+   * @returns {string}
+   */
+  getEmailId(message) {
+    return message.getId();
+  },
+
+  /**
+   * Retorna el asunto del mensaje (para logging).
+   * @param {GmailMessage} message
+   * @returns {string}
+   */
+  getSubject(message) {
+    return message.getSubject();
+  }
+};

--- a/src/main.gs
+++ b/src/main.gs
@@ -1,0 +1,332 @@
+/**
+ * main.gs — Orquestador principal del pipeline de ingesta de emails
+ *
+ * Punto de entrada para el trigger diario de Apps Script.
+ * Ejecutar main() desde el trigger de Apps Script.
+ *
+ * SETUP DEL TRIGGER:
+ * Para configurar el trigger automático, ejecutar setupDailyTrigger() una vez.
+ */
+
+/**
+ * Registro de parsers por clave de banco.
+ */
+const ParserRegistry = {
+  bcp: BcpParser,
+  interbank: InterbankParser,
+  bbva: BbvaParser,
+  scotiabank: ScotiabankParser,
+  yape: YapeParser,
+  plin: PlinParser,
+
+  /**
+   * Retorna el parser para el banco dado.
+   * @param {string} bancoKey - Clave del banco (ej. "bcp")
+   * @returns {Object|null}
+   */
+  getParser(bancoKey) {
+    return this[bancoKey] || null;
+  }
+};
+
+/**
+ * Entry point principal del pipeline.
+ * Puede ser llamado manualmente o por un trigger diario de Apps Script.
+ */
+function main() {
+  const startTime = Date.now();
+  log('INFO', '=== Pipeline iniciado ===', { usuario: CONFIG.usuario });
+
+  // Contadores para resumen final
+  const stats = {
+    procesados: 0,
+    errores: 0,
+    deduplicados: 0,
+    bancoStats: {}
+  };
+
+  // Verificar configuración mínima
+  if (CONFIG.spreadsheetId === 'SHEET_ID_AQUI') {
+    log('ERROR', 'CONFIG.spreadsheetId no configurado. Actualizar config.gs antes de ejecutar.');
+    return;
+  }
+
+  if (!CONFIG.claudeApiKey) {
+    log('WARN', 'CLAUDE_API_KEY no encontrada en PropertiesService. Categorización y fallback AI desactivados.');
+  }
+
+  // Asegurar headers en la hoja
+  try {
+    SheetsService.ensureHeaders();
+  } catch (e) {
+    log('ERROR', 'No se pudo acceder a Google Sheets. Abortando.', { error: e.message });
+    return;
+  }
+
+  // Cargar IDs de emails ya procesados (deduplicación secundaria)
+  const processedIds = SheetsService.getProcessedEmailIds();
+
+  // Procesar cada banco habilitado
+  for (const [bancoKey, bankConfig] of Object.entries(CONFIG.bancos)) {
+    if (!bankConfig.enabled) {
+      log('INFO', 'Banco deshabilitado, omitiendo', { banco: bankConfig.banco_nombre });
+      continue;
+    }
+
+    stats.bancoStats[bancoKey] = { procesados: 0, errores: 0, deduplicados: 0 };
+
+    // Verificar límite de tiempo antes de cada banco
+    if (Date.now() - startTime > CONFIG.maxExecutionMs) {
+      log('WARN', 'Límite de tiempo alcanzado. Guardando checkpoint.', { banco: bancoKey });
+      _saveCheckpoint(bancoKey, stats);
+      break;
+    }
+
+    const emails = GmailService.searchEmails(bankConfig);
+
+    for (const email of emails) {
+      // Verificar límite de tiempo antes de cada email
+      if (Date.now() - startTime > CONFIG.maxExecutionMs) {
+        log('WARN', 'Límite de tiempo alcanzado durante procesamiento de emails.', { banco: bancoKey });
+        _saveCheckpoint(bancoKey, stats);
+        break;
+      }
+
+      const emailId = GmailService.getEmailId(email);
+      const subject = GmailService.getSubject(email);
+
+      // Deduplicación secundaria (capa Sheets)
+      if (processedIds.has(emailId)) {
+        log('INFO', 'Email ya procesado (dedup Sheets), omitiendo', { emailId });
+        stats.deduplicados++;
+        stats.bancoStats[bancoKey].deduplicados++;
+        continue;
+      }
+
+      // Procesar el email (fail-open: errores individuales no interrumpen el pipeline)
+      try {
+        const result = _processEmail(email, emailId, bankConfig);
+
+        if (result.success) {
+          stats.procesados++;
+          stats.bancoStats[bancoKey].procesados++;
+          processedIds.add(emailId);
+        } else {
+          stats.errores++;
+          stats.bancoStats[bancoKey].errores++;
+        }
+      } catch (e) {
+        log('ERROR', 'Error inesperado procesando email', {
+          emailId,
+          subject,
+          banco: bancoKey,
+          error: e.message
+        });
+        stats.errores++;
+        stats.bancoStats[bancoKey].errores++;
+        // Registrar en Sheets como parse_error y aplicar label de error
+        _handleEmailError(email, emailId, bankConfig, e.message);
+      }
+    }
+  }
+
+  const elapsed = Math.round((Date.now() - startTime) / 1000);
+  log('INFO', '=== Pipeline finalizado ===', {
+    usuario: CONFIG.usuario,
+    procesados: stats.procesados,
+    errores: stats.errores,
+    deduplicados: stats.deduplicados,
+    elapsed_s: elapsed,
+    bancoStats: stats.bancoStats
+  });
+}
+
+/**
+ * Procesa un email individual: parseo → categorización → escritura en Sheets → label.
+ * @param {GmailMessage} email
+ * @param {string} emailId
+ * @param {Object} bankConfig
+ * @returns {{success: boolean}}
+ */
+function _processEmail(email, emailId, bankConfig) {
+  const subject = GmailService.getSubject(email);
+  const body = GmailService.getEmailBody(email);
+
+  if (!body) {
+    log('WARN', 'Email sin cuerpo', { emailId, subject });
+    _writeRow({
+      email_id: emailId,
+      banco: bankConfig.banco_nombre,
+      status: 'parse_error',
+      comercio: subject || 'Sin asunto'
+    });
+    GmailService.applyLabel(email, bankConfig.label_error);
+    return { success: false };
+  }
+
+  // Obtener el parser para este banco
+  const parser = ParserRegistry.getParser(bankConfig.parser);
+  if (!parser) {
+    log('ERROR', 'Parser no encontrado para banco', { banco: bankConfig.parser });
+    return { success: false };
+  }
+
+  // Intentar parseo con regex
+  let parsed = parser.parse(body);
+  let parsed_by_ai = false;
+
+  // Fallback a Claude API si el regex falla y está habilitado
+  if (!parsed && bankConfig.fallback_ai && CONFIG.claudeApiKey) {
+    log('INFO', 'Regex falló, intentando Claude API fallback', {
+      emailId,
+      banco: bankConfig.banco_nombre
+    });
+    const aiResult = ClaudeService.parseWithAI(body, bankConfig.banco_nombre);
+    if (aiResult) {
+      parsed = aiResult;
+      parsed_by_ai = true;
+    }
+  }
+
+  // Si no se pudo parsear, registrar como error
+  if (!parsed) {
+    log('WARN', 'No se pudo parsear email', {
+      emailId,
+      banco: bankConfig.banco_nombre,
+      subject
+    });
+    _writeRow({
+      email_id: emailId,
+      banco: bankConfig.banco_nombre,
+      status: 'parse_error',
+      comercio: subject || 'Sin asunto',
+      parsed_by_ai: false
+    });
+    GmailService.applyLabel(email, bankConfig.label_error);
+    return { success: false };
+  }
+
+  // Categorizar con Claude API
+  let categoria = 'Sin categorizar';
+  let categorized_by_ai = false;
+
+  if (CONFIG.claudeApiKey) {
+    const catResult = ClaudeService.categorize(
+      parsed.comercio,
+      parsed.monto,
+      bankConfig.banco_nombre
+    );
+    categoria = catResult.categoria;
+    categorized_by_ai = catResult.categorized_by_ai;
+  }
+
+  // Escribir en Sheets
+  _writeRow({
+    fecha: parsed.fecha,
+    monto: parsed.monto,
+    comercio: parsed.comercio,
+    banco: bankConfig.banco_nombre,
+    usuario: CONFIG.usuario,
+    categoria,
+    categorized_by_ai,
+    parsed_by_ai,
+    status: 'ok',
+    email_id: emailId
+  });
+
+  // Aplicar label de procesado exitoso
+  GmailService.applyLabel(email, bankConfig.label_procesado);
+
+  log('INFO', 'Email procesado exitosamente', {
+    emailId,
+    banco: bankConfig.banco_nombre,
+    monto: parsed.monto,
+    categoria
+  });
+
+  return { success: true };
+}
+
+/**
+ * Escribe una fila en Sheets con valores por defecto para campos faltantes.
+ * @param {Object} fields
+ */
+function _writeRow(fields) {
+  SheetsService.appendRow({
+    fecha: fields.fecha || '',
+    monto: fields.monto || 0,
+    comercio: fields.comercio || '',
+    banco: fields.banco || '',
+    usuario: fields.usuario || CONFIG.usuario,
+    categoria: fields.categoria || 'Sin categorizar',
+    categorized_by_ai: fields.categorized_by_ai || false,
+    parsed_by_ai: fields.parsed_by_ai || false,
+    status: fields.status || 'ok',
+    email_id: fields.email_id || '',
+    timestamp_ingesta: getNowLima()
+  });
+}
+
+/**
+ * Maneja un error inesperado en el procesamiento de un email.
+ * Registra en Sheets como parse_error y aplica label de error.
+ */
+function _handleEmailError(email, emailId, bankConfig, errorMessage) {
+  try {
+    _writeRow({
+      email_id: emailId,
+      banco: bankConfig.banco_nombre,
+      status: 'parse_error',
+      comercio: `Error: ${errorMessage}`.substring(0, 100)
+    });
+    GmailService.applyLabel(email, bankConfig.label_error);
+  } catch (e) {
+    log('ERROR', 'Error al manejar error de email', { emailId, error: e.message });
+  }
+}
+
+/**
+ * Guarda un checkpoint en PropertiesService para continuar en la próxima ejecución.
+ * @param {string} lastBancoKey - Último banco procesado
+ * @param {Object} stats - Estadísticas actuales
+ */
+function _saveCheckpoint(lastBancoKey, stats) {
+  try {
+    const checkpoint = {
+      lastBancoKey,
+      stats,
+      timestamp: getNowLima()
+    };
+    PropertiesService.getScriptProperties().setProperty(
+      'PIPELINE_CHECKPOINT',
+      JSON.stringify(checkpoint)
+    );
+    log('INFO', 'Checkpoint guardado', { lastBancoKey });
+  } catch (e) {
+    log('ERROR', 'Error guardando checkpoint', { error: e.message });
+  }
+}
+
+/**
+ * Configura un trigger diario a las 7:00 AM hora de Lima.
+ * Ejecutar esta función una sola vez para configurar el trigger.
+ */
+function setupDailyTrigger() {
+  // Eliminar triggers existentes de main para evitar duplicados
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'main') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  // Crear trigger diario a las 7 AM
+  ScriptApp.newTrigger('main')
+    .timeBased()
+    .atHour(7)
+    .everyDays(1)
+    .inTimezone('America/Lima')
+    .create();
+
+  log('INFO', 'Trigger diario configurado para las 7:00 AM hora de Lima');
+}

--- a/src/main.gs
+++ b/src/main.gs
@@ -16,6 +16,7 @@ const ParserRegistry = {
   interbank: InterbankParser,
   bbva: BbvaParser,
   scotiabank: ScotiabankParser,
+  diners: DinersParser,
   yape: YapeParser,
   plin: PlinParser,
 

--- a/src/parsers/bbva-parser.gs
+++ b/src/parsers/bbva-parser.gs
@@ -1,0 +1,88 @@
+/**
+ * bbva-parser.gs — Parser para emails de BBVA Perú
+ *
+ * Formatos reconocidos:
+ * - "Alerta de compra con tu tarjeta BBVA"
+ * - Monto: "S/ 89.90" o "USD 15.00"
+ * - Fecha: DD/MM/YYYY
+ * - Comercio: nombre del establecimiento
+ */
+
+const BbvaParser = {
+  /**
+   * Parsea el cuerpo de un email de BBVA.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractComercio(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ii]mporte[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]ompra\s+por\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /USD\s+([\d,]+\.?\d{0,2})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /(\d{2}\/\d{2}\/\d{4})/,
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractComercio(body) {
+    const patterns = [
+      /[Ee]n\s+([A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s\.\-&']{2,50}?)(?:\s*\n|\s{2,}|$)/m,
+      /[Cc]omercio[:\s]+([^\n]{2,60})/i,
+      /[Ee]stablecimiento[:\s]+([^\n]{2,60})/i,
+      /[Ll]ugar[:\s]+([^\n]{2,60})/i,
+      /[Aa]l\s+comercio\s+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const comercio = normalizeText(m[1]);
+        if (comercio.length >= 2) return comercio;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/bcp-parser.gs
+++ b/src/parsers/bcp-parser.gs
@@ -1,0 +1,88 @@
+/**
+ * bcp-parser.gs — Parser para emails de BCP
+ *
+ * Formatos reconocidos:
+ * - "Consumo con tu Tarjeta de Débito/Crédito BCP"
+ * - Monto: "S/ 150.00" o "S/150.00"
+ * - Fecha: "15/01/2026" o "15 de enero de 2026"
+ * - Comercio: texto en mayúsculas tras "en " o "Comercio:"
+ */
+
+const BcpParser = {
+  /**
+   * Parsea el cuerpo de un email de BCP.
+   * @param {string} body - Cuerpo del email en texto plano
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractComercio(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    // Patrones: "S/ 1,234.56", "S/1234.56", "S/ 150.00"
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ii]mporte[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]onsumaste\s+S\/\s*([\d,]+\.?\d{0,2})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /[Ff]echa[:\s]+(\d{1,2}\s+de\s+\w+\s+de\s+\d{4})/i,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractComercio(body) {
+    const patterns = [
+      /[Ee]n\s+([A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s\.\-&']{2,50}?)(?:\s*\n|\s{2,}|$)/m,
+      /[Cc]omercio[:\s]+([^\n]{2,60})/i,
+      /[Ee]stablecimiento[:\s]+([^\n]{2,60})/i,
+      /[Ll]ugar[:\s]+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const comercio = normalizeText(m[1]);
+        if (comercio.length >= 2) return comercio;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/diners-parser.gs
+++ b/src/parsers/diners-parser.gs
@@ -1,0 +1,90 @@
+/**
+ * diners-parser.gs — Parser para emails de Diners Club Perú
+ *
+ * Formatos reconocidos:
+ * - Notificación de compra/consumo Diners Club (avisos@dinersenlinea.pe)
+ * - Monto: "S/ 150.00" o "USD 25.00"
+ * - Fecha: DD/MM/YYYY o textual
+ * - Comercio: nombre del establecimiento
+ */
+
+const DinersParser = {
+  /**
+   * Parsea el cuerpo de un email de Diners Club.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractComercio(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ii]mporte[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]ompra\s+por\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]onsumo\s+de\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /USD\s+([\d,]+\.?\d{0,2})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i,
+      /(\d{2}\/\d{2}\/\d{4})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractComercio(body) {
+    const patterns = [
+      /[Ee]n\s+([A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s\.\-&']{2,50}?)(?:\s*\n|\s{2,}|$)/m,
+      /[Cc]omercio[:\s]+([^\n]{2,60})/i,
+      /[Ee]stablecimiento[:\s]+([^\n]{2,60})/i,
+      /[Ll]ugar[:\s]+([^\n]{2,60})/i,
+      /[Mm]ediant[e]?\s+tu\s+tarjeta\s+en\s+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const comercio = normalizeText(m[1]);
+        if (comercio.length >= 2) return comercio;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/interbank-parser.gs
+++ b/src/parsers/interbank-parser.gs
@@ -1,0 +1,88 @@
+/**
+ * interbank-parser.gs — Parser para emails de Interbank
+ *
+ * Formatos reconocidos:
+ * - Alerta de consumo Interbank
+ * - Monto: "S/ 250.00" o con separadores de miles
+ * - Fecha: DD/MM/YYYY o "15 de enero de 2026"
+ * - Comercio: nombre del establecimiento
+ */
+
+const InterbankParser = {
+  /**
+   * Parsea el cuerpo de un email de Interbank.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractComercio(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ii]mporte[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]onsumo\s+de\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]argo\s+de\s+S\/\s*([\d,]+\.?\d{0,2})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i,
+      /[Ff]echa\s+de\s+(?:consumo|operación)[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractComercio(body) {
+    const patterns = [
+      /[Ee]n\s+([A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s\.\-&']{2,50}?)(?:\s*\n|\s{2,}|$)/m,
+      /[Ee]stablecimiento[:\s]+([^\n]{2,60})/i,
+      /[Cc]omercio[:\s]+([^\n]{2,60})/i,
+      /[Ll]ugar\s+de\s+consumo[:\s]+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const comercio = normalizeText(m[1]);
+        if (comercio.length >= 2) return comercio;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/plin-parser.gs
+++ b/src/parsers/plin-parser.gs
@@ -1,0 +1,89 @@
+/**
+ * plin-parser.gs — Parser para emails de Plin
+ *
+ * Formatos reconocidos:
+ * - Confirmación de pago enviado con Plin
+ * - Monto: "S/ [monto]"
+ * - Destinatario: nombre de quien recibió el pago
+ * - Fecha: DD/MM/YYYY o textual
+ */
+
+const PlinParser = {
+  /**
+   * Parsea el cuerpo de un email de Plin.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractDestinatario(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /por\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Tt]ransferiste\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ee]nviaste\s+S\/\s*([\d,]+\.?\d{0,2})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i,
+      /(\d{2}\/\d{2}\/\d{4})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractDestinatario(body) {
+    const patterns = [
+      /[Ee]nviaste\s+(?:dinero\s+)?a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Tt]ransferiste\s+a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Pp]ago\s+a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Pp]ara[:\s]+([^\n\r]{2,50}?)(?:\s*\n|\s+[Ss]\/)/i,
+      /[Dd]estinatario[:\s]+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const dest = normalizeText(m[1]);
+        if (dest.length >= 2) return dest;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/scotiabank-parser.gs
+++ b/src/parsers/scotiabank-parser.gs
@@ -1,0 +1,88 @@
+/**
+ * scotiabank-parser.gs — Parser para emails de Scotiabank Perú
+ *
+ * Formatos reconocidos:
+ * - Notificación de consumo Scotiabank
+ * - Monto: "S/ 320.00"
+ * - Fecha: DD/MM/YYYY o textual
+ * - Comercio: nombre del establecimiento
+ */
+
+const ScotiabankParser = {
+  /**
+   * Parsea el cuerpo de un email de Scotiabank.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractComercio(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ii]mporte[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Cc]onsumo\s+de\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Uu]tilizaste\s+S\/\s*([\d,]+\.?\d{0,2})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i,
+      /(\d{2}\/\d{2}\/\d{4})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractComercio(body) {
+    const patterns = [
+      /[Ee]n\s+([A-ZÁÉÍÓÚÑ][A-ZÁÉÍÓÚÑ\s\.\-&']{2,50}?)(?:\s*\n|\s{2,}|$)/m,
+      /[Cc]omercio[:\s]+([^\n]{2,60})/i,
+      /[Ee]stablecimiento[:\s]+([^\n]{2,60})/i,
+      /[Tt]ienda[:\s]+([^\n]{2,60})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const comercio = normalizeText(m[1]);
+        if (comercio.length >= 2) return comercio;
+      }
+    }
+    return null;
+  }
+};

--- a/src/parsers/yape-parser.gs
+++ b/src/parsers/yape-parser.gs
@@ -1,0 +1,85 @@
+/**
+ * yape-parser.gs — Parser para emails de Yape
+ *
+ * Formatos reconocidos:
+ * - "Realizaste un pago a [Nombre] por S/ [monto]"
+ * - Fecha: DD/MM/YYYY o textual en el cuerpo
+ */
+
+const YapeParser = {
+  /**
+   * Parsea el cuerpo de un email de Yape.
+   * @param {string} body
+   * @returns {{fecha: string, monto: number, comercio: string, raw: string}|null}
+   */
+  parse(body) {
+    if (!body) return null;
+
+    const monto = this._extractMonto(body);
+    const fecha = this._extractFecha(body);
+    const comercio = this._extractDestinatario(body);
+
+    if (!monto || !fecha) return null;
+
+    return {
+      fecha,
+      monto,
+      comercio: comercio || 'Desconocido',
+      raw: body
+    };
+  },
+
+  _extractMonto(body) {
+    const patterns = [
+      /por\s+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Ss]\/\s*([\d,]+\.?\d{0,2})/,
+      /[Mm]onto[:\s]+S\/\s*([\d,]+\.?\d{0,2})/i,
+      /[Pp]agaste\s+S\/\s*([\d,]+\.?\d{0,2})/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const amount = parseAmount(m[1]);
+        if (amount) return amount;
+      }
+    }
+    return null;
+  },
+
+  _extractFecha(body) {
+    const patterns = [
+      /[Ff]echa[:\s]+(\d{1,2}\/\d{1,2}\/\d{4})/,
+      /(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}/,
+      /(\d{1,2}\s+de\s+(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?\d{4})/i,
+      /(\d{2}\/\d{2}\/\d{4})/
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const date = parseDate(m[1]);
+        if (date) return date;
+      }
+    }
+    return null;
+  },
+
+  _extractDestinatario(body) {
+    const patterns = [
+      /[Pp]agaste\s+a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Pp]ago\s+a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Rr]ealizaste\s+un\s+pago\s+a\s+([^\n\r]{2,50}?)(?:\s+por\s+S\/|\s*\n)/i,
+      /[Pp]ara[:\s]+([^\n\r]{2,50}?)(?:\s*\n|\s+[Ss]\/)/i
+    ];
+
+    for (const pattern of patterns) {
+      const m = body.match(pattern);
+      if (m) {
+        const dest = normalizeText(m[1]);
+        if (dest.length >= 2) return dest;
+      }
+    }
+    return null;
+  }
+};

--- a/src/sheets-service.gs
+++ b/src/sheets-service.gs
@@ -1,0 +1,118 @@
+/**
+ * sheets-service.gs — Abstracción sobre SpreadsheetApp para lectura/escritura
+ *
+ * Columnas (A-K):
+ * A: fecha, B: monto, C: comercio, D: banco, E: usuario,
+ * F: categoria, G: categorized_by_ai, H: parsed_by_ai,
+ * I: status, J: email_id, K: timestamp_ingesta
+ */
+
+const SHEET_HEADERS = [
+  'fecha', 'monto', 'comercio', 'banco', 'usuario',
+  'categoria', 'categorized_by_ai', 'parsed_by_ai',
+  'status', 'email_id', 'timestamp_ingesta'
+];
+
+// Índice (0-based) de la columna email_id en SHEET_HEADERS
+const EMAIL_ID_COL_INDEX = 9;
+
+const SheetsService = {
+  /**
+   * Obtiene la hoja de gastos, creándola si no existe.
+   * @returns {Sheet}
+   */
+  getSheet() {
+    const ss = SpreadsheetApp.openById(CONFIG.spreadsheetId);
+    let sheet = ss.getSheetByName(CONFIG.sheetName);
+    if (!sheet) {
+      sheet = ss.insertSheet(CONFIG.sheetName);
+      log('INFO', 'Hoja creada', { sheetName: CONFIG.sheetName });
+    }
+    return sheet;
+  },
+
+  /**
+   * Asegura que la primera fila tenga los headers correctos.
+   * Solo escribe si la hoja está vacía.
+   */
+  ensureHeaders() {
+    const sheet = this.getSheet();
+    if (sheet.getLastRow() === 0) {
+      sheet.appendRow(SHEET_HEADERS);
+      sheet.getRange(1, 1, 1, SHEET_HEADERS.length).setFontWeight('bold');
+      log('INFO', 'Headers creados en hoja', { sheetName: CONFIG.sheetName });
+    }
+  },
+
+  /**
+   * Lee todos los email_ids ya procesados para deduplicación.
+   * @returns {Set<string>}
+   */
+  getProcessedEmailIds() {
+    try {
+      const sheet = this.getSheet();
+      const lastRow = sheet.getLastRow();
+
+      if (lastRow <= 1) {
+        return new Set();
+      }
+
+      // Columna J (email_id) = columna 10 (1-based)
+      const emailIdColNum = EMAIL_ID_COL_INDEX + 1;
+      const values = sheet
+        .getRange(2, emailIdColNum, lastRow - 1, 1)
+        .getValues();
+
+      const ids = new Set();
+      for (const [id] of values) {
+        if (id) ids.add(String(id));
+      }
+
+      log('INFO', 'Email IDs procesados cargados', { count: ids.size });
+      return ids;
+    } catch (e) {
+      log('ERROR', 'Error leyendo email_ids de Sheets', { error: e.message });
+      return new Set();
+    }
+  },
+
+  /**
+   * Agrega una fila de gasto a la hoja.
+   * @param {Object} row - Objeto con los campos del gasto
+   * @param {string} row.fecha
+   * @param {number} row.monto
+   * @param {string} row.comercio
+   * @param {string} row.banco
+   * @param {string} row.usuario
+   * @param {string} row.categoria
+   * @param {boolean} row.categorized_by_ai
+   * @param {boolean} row.parsed_by_ai
+   * @param {string} row.status
+   * @param {string} row.email_id
+   * @param {string} row.timestamp_ingesta
+   */
+  appendRow(row) {
+    try {
+      const sheet = this.getSheet();
+      sheet.appendRow([
+        row.fecha || '',
+        row.monto || 0,
+        row.comercio || '',
+        row.banco || '',
+        row.usuario || CONFIG.usuario,
+        row.categoria || 'Sin categorizar',
+        row.categorized_by_ai || false,
+        row.parsed_by_ai || false,
+        row.status || 'ok',
+        row.email_id || '',
+        row.timestamp_ingesta || getNowLima()
+      ]);
+    } catch (e) {
+      log('ERROR', 'Error escribiendo fila en Sheets', {
+        email_id: row.email_id,
+        error: e.message
+      });
+      throw e;
+    }
+  }
+};

--- a/src/utils.gs
+++ b/src/utils.gs
@@ -1,0 +1,171 @@
+/**
+ * utils.gs — Funciones helper reutilizables
+ */
+
+const MESES_ES = {
+  enero: '01', febrero: '02', marzo: '03', abril: '04',
+  mayo: '05', junio: '06', julio: '07', agosto: '08',
+  septiembre: '09', octubre: '10', noviembre: '11', diciembre: '12'
+};
+
+/**
+ * Parsea una cadena de fecha a formato YYYY-MM-DD.
+ * Soporta: DD/MM/YYYY, DD-MM-YYYY, YYYY-MM-DD, "15 de enero de 2026"
+ * @param {string} str
+ * @returns {string|null} YYYY-MM-DD o null si no puede parsear
+ */
+function parseDate(str) {
+  if (!str) return null;
+  const s = str.trim();
+
+  // YYYY-MM-DD
+  let m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (m) return s;
+
+  // DD/MM/YYYY o DD-MM-YYYY
+  m = s.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/);
+  if (m) {
+    const [, d, mo, y] = m;
+    return `${y}-${mo.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  }
+
+  // "15 de enero de 2026" o "15 enero 2026"
+  m = s.match(/(\d{1,2})\s+(?:de\s+)?([a-záéíóúü]+)(?:\s+de)?\s+(\d{4})/i);
+  if (m) {
+    const [, d, mesStr, y] = m;
+    const mes = MESES_ES[mesStr.toLowerCase()];
+    if (mes) return `${y}-${mes}-${d.padStart(2, '0')}`;
+  }
+
+  // DD/MM/YY
+  m = s.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2})$/);
+  if (m) {
+    const [, d, mo, y] = m;
+    const year = parseInt(y) < 50 ? `20${y}` : `19${y}`;
+    return `${year}-${mo.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  }
+
+  return null;
+}
+
+/**
+ * Parsea una cadena de monto a número.
+ * Soporta: "S/ 1,234.56", "S/1234.56", "1.234,56", "1234.56", "USD 25.00"
+ * @param {string} str
+ * @returns {number|null}
+ */
+function parseAmount(str) {
+  if (!str) return null;
+
+  // Quitar símbolo de moneda y espacios
+  let s = str.replace(/S\/\s*/i, '').replace(/USD\s*/i, '').replace(/PEN\s*/i, '').trim();
+
+  // Detectar formato europeo: 1.234,56
+  if (/^\d{1,3}(\.\d{3})+(,\d{2})?$/.test(s)) {
+    s = s.replace(/\./g, '').replace(',', '.');
+  } else {
+    // Formato americano: 1,234.56 — quitar comas de miles
+    s = s.replace(/,/g, '');
+  }
+
+  const n = parseFloat(s);
+  if (isNaN(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * Normaliza texto: trim, colapsa espacios múltiples, mayúsculas.
+ * @param {string} str
+ * @returns {string}
+ */
+function normalizeText(str) {
+  if (!str) return '';
+  return str.trim().replace(/\s+/g, ' ').toUpperCase();
+}
+
+/**
+ * Sanitiza el cuerpo del email para enviar a Claude API.
+ * Remueve caracteres de control y trunca a maxChars.
+ * @param {string} str
+ * @param {number} [maxChars]
+ * @returns {string}
+ */
+function sanitizeForPrompt(str, maxChars) {
+  if (!str) return '';
+  const max = maxChars || CONFIG.maxEmailBodyChars;
+  // Remover caracteres de control excepto \n y \t
+  let s = str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ');
+  // Colapsar líneas en blanco múltiples
+  s = s.replace(/\n{3,}/g, '\n\n');
+  // Truncar
+  if (s.length > max) {
+    s = s.substring(0, max) + '\n[... truncado]';
+  }
+  return s;
+}
+
+/**
+ * Extrae texto plano de un cuerpo HTML (naive, para fallback).
+ * @param {string} html
+ * @returns {string}
+ */
+function htmlToText(html) {
+  if (!html) return '';
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<p[^>]*>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Retorna timestamp actual en zona horaria America/Lima (UTC-5).
+ * @returns {string} ISO 8601
+ */
+function getNowLima() {
+  const now = new Date();
+  // Lima es UTC-5 sin horario de verano
+  const limaOffset = -5 * 60;
+  const utcOffset = now.getTimezoneOffset();
+  const limaMs = now.getTime() + (utcOffset + limaOffset) * 60 * 1000;
+  const lima = new Date(limaMs);
+
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${lima.getFullYear()}-${pad(lima.getMonth() + 1)}-${pad(lima.getDate())}T` +
+         `${pad(lima.getHours())}:${pad(lima.getMinutes())}:${pad(lima.getSeconds())}-05:00`;
+}
+
+/**
+ * Logger que omite cuerpos de email para proteger datos sensibles.
+ * @param {'INFO'|'WARN'|'ERROR'} level
+ * @param {string} message
+ * @param {Object} [data]
+ */
+function log(level, message, data) {
+  const ts = getNowLima();
+  const safe = data ? JSON.stringify(data) : '';
+  console.log(`[${ts}] [${level}] ${message} ${safe}`);
+}
+
+/**
+ * Obtiene o crea un label de Gmail por nombre.
+ * @param {string} labelName
+ * @returns {GmailLabel}
+ */
+function getOrCreateLabel(labelName) {
+  let label = GmailApp.getUserLabelByName(labelName);
+  if (!label) {
+    label = GmailApp.createLabel(labelName);
+  }
+  return label;
+}

--- a/tests/claude-service-test.gs
+++ b/tests/claude-service-test.gs
@@ -1,0 +1,150 @@
+/**
+ * claude-service-test.gs — Tests para ClaudeService con mock de UrlFetchApp
+ *
+ * IMPORTANTE: Estos tests mockean UrlFetchApp para no hacer llamadas reales a Claude API.
+ * Los mocks se restauran al final de cada test.
+ */
+
+/**
+ * Mock de UrlFetchApp para tests.
+ * Reemplaza temporalmente UrlFetchApp.fetch con una función configurable.
+ */
+function withMockFetch(mockResponse, fn) {
+  const original = UrlFetchApp.fetch;
+  UrlFetchApp.fetch = () => ({
+    getResponseCode: () => mockResponse.status || 200,
+    getContentText: () => JSON.stringify(mockResponse.body || {})
+  });
+  try {
+    fn();
+  } finally {
+    UrlFetchApp.fetch = original;
+  }
+}
+
+function makeClaudeResponse(text) {
+  return {
+    status: 200,
+    body: {
+      content: [{ type: 'text', text }]
+    }
+  };
+}
+
+TestRunner.suite('ClaudeService — categorize', ({ test, assert }) => {
+  test('retorna categoría válida cuando Claude responde correctamente', () => {
+    withMockFetch(makeClaudeResponse('Supermercado'), () => {
+      // Temporalmente proveer una API key para el test
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) => {
+        if (key === 'CLAUDE_API_KEY') return 'test-key-mock';
+        return origGet.call(PropertiesService.getScriptProperties(), key);
+      };
+
+      const result = ClaudeService.categorize('WONG LAS BEGONIAS', 89.50, 'BCP');
+      assert.equal(result.categoria, 'Supermercado');
+      assert.isTrue(result.categorized_by_ai);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna "Otro" cuando Claude responde con categoría no válida', () => {
+    withMockFetch(makeClaudeResponse('CategoriaInventada'), () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.categorize('COMERCIO X', 100, 'BCP');
+      assert.equal(result.categoria, 'Otro');
+      assert.isTrue(result.categorized_by_ai);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna "Sin categorizar" cuando Claude API falla (error HTTP)', () => {
+    withMockFetch({ status: 500, body: { error: 'internal error' } }, () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.categorize('COMERCIO X', 100, 'BCP');
+      assert.equal(result.categoria, 'Sin categorizar');
+      assert.isFalse(result.categorized_by_ai);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna "Sin categorizar" cuando no hay API key', () => {
+    const origGet = PropertiesService.getScriptProperties().getProperty;
+    PropertiesService.getScriptProperties().getProperty = (key) =>
+      key === 'CLAUDE_API_KEY' ? null : origGet.call(PropertiesService.getScriptProperties(), key);
+
+    const result = ClaudeService.categorize('COMERCIO X', 100, 'BCP');
+    assert.equal(result.categoria, 'Sin categorizar');
+    assert.isFalse(result.categorized_by_ai);
+
+    PropertiesService.getScriptProperties().getProperty = origGet;
+  });
+});
+
+TestRunner.suite('ClaudeService — parseWithAI', ({ test, assert }) => {
+  const validAiParseBody = '{"fecha": "2026-01-15", "monto": 89.50, "comercio": "WONG"}';
+
+  test('retorna datos parseados cuando Claude responde con JSON válido', () => {
+    withMockFetch(makeClaudeResponse(validAiParseBody), () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.parseWithAI('cuerpo de email', 'BCP');
+      assert.isNotNull(result);
+      assert.equal(result.fecha, '2026-01-15');
+      assert.closeTo(result.monto, 89.50, 0.001);
+      assert.isTrue(result.parsed_by_ai);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna null cuando Claude responde con JSON incompleto (sin monto)', () => {
+    withMockFetch(makeClaudeResponse('{"fecha": "2026-01-15", "monto": null, "comercio": "WONG"}'), () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.parseWithAI('cuerpo de email', 'BCP');
+      assert.isNull(result);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna null cuando Claude responde con texto no-JSON', () => {
+    withMockFetch(makeClaudeResponse('No pude extraer los datos del email.'), () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.parseWithAI('cuerpo de email', 'BCP');
+      assert.isNull(result);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+
+  test('retorna null cuando API devuelve error 429', () => {
+    withMockFetch({ status: 429, body: { error: 'rate limit' } }, () => {
+      const origGet = PropertiesService.getScriptProperties().getProperty;
+      PropertiesService.getScriptProperties().getProperty = (key) =>
+        key === 'CLAUDE_API_KEY' ? 'test-key-mock' : origGet.call(PropertiesService.getScriptProperties(), key);
+
+      const result = ClaudeService.parseWithAI('cuerpo de email', 'BCP');
+      assert.isNull(result);
+
+      PropertiesService.getScriptProperties().getProperty = origGet;
+    });
+  });
+});

--- a/tests/gmail-service-test.gs
+++ b/tests/gmail-service-test.gs
@@ -1,0 +1,138 @@
+/**
+ * gmail-service-test.gs — Tests para GmailService con mock de GmailApp
+ */
+
+/**
+ * Crea un mock de GmailMessage.
+ */
+function makeMockMessage(opts) {
+  return {
+    getId: () => opts.id || 'msg-001',
+    getSubject: () => opts.subject || 'Test email',
+    getPlainBody: () => opts.plainBody || '',
+    getBody: () => opts.htmlBody || '',
+    getThread: () => ({
+      addLabel: (label) => { opts._labelAdded = label; }
+    })
+  };
+}
+
+/**
+ * Crea un mock de GmailThread con un mensaje.
+ */
+function makeMockThread(message) {
+  return {
+    getMessages: () => [message]
+  };
+}
+
+TestRunner.suite('GmailService — buildQuery', ({ test, assert }) => {
+  const bankConfig = {
+    banco_nombre: 'BCP',
+    gmail_query: 'from:(alertas@notificacionesbcp.com.pe) subject:(consumo)',
+    label_procesado: 'ingesta/bcp/ok',
+    label_error: 'ingesta/bcp/error'
+  };
+
+  test('incluye la query base del banco', () => {
+    const query = GmailService.buildQuery(bankConfig);
+    assert.isTrue(query.includes('from:(alertas@notificacionesbcp.com.pe)'));
+  });
+
+  test('excluye emails con label ok', () => {
+    const query = GmailService.buildQuery(bankConfig);
+    assert.isTrue(query.includes('-label:ingesta/bcp/ok'));
+  });
+
+  test('excluye emails con label error', () => {
+    const query = GmailService.buildQuery(bankConfig);
+    assert.isTrue(query.includes('-label:ingesta/bcp/error'));
+  });
+});
+
+TestRunner.suite('GmailService — getEmailBody', ({ test, assert }) => {
+  test('retorna cuerpo plain text cuando está disponible', () => {
+    const msg = makeMockMessage({ plainBody: 'Texto plano del email' });
+    const body = GmailService.getEmailBody(msg);
+    assert.equal(body, 'Texto plano del email');
+  });
+
+  test('convierte HTML cuando no hay plain text', () => {
+    const msg = makeMockMessage({
+      plainBody: '',
+      htmlBody: '<p>Monto: <b>S/ 89.50</b></p>'
+    });
+    const body = GmailService.getEmailBody(msg);
+    assert.isTrue(body.includes('S/'));
+    assert.isTrue(body.includes('89.50'));
+  });
+
+  test('retorna string vacío si ambos cuerpos están vacíos', () => {
+    const msg = makeMockMessage({ plainBody: '', htmlBody: '' });
+    const body = GmailService.getEmailBody(msg);
+    assert.equal(body, '');
+  });
+});
+
+TestRunner.suite('GmailService — searchEmails', ({ test, assert }) => {
+  test('retorna arreglo vacío cuando Gmail no encuentra emails', () => {
+    const origSearch = GmailApp.search;
+    GmailApp.search = () => [];
+
+    const bankConfig = {
+      banco_nombre: 'BCP',
+      gmail_query: 'from:(test@test.com)',
+      label_procesado: 'ingesta/bcp/ok',
+      label_error: 'ingesta/bcp/error'
+    };
+
+    const emails = GmailService.searchEmails(bankConfig);
+    assert.equal(emails.length, 0);
+
+    GmailApp.search = origSearch;
+  });
+
+  test('retorna el primer mensaje de cada thread', () => {
+    const msg1 = makeMockMessage({ id: 'msg-001' });
+    const msg2 = makeMockMessage({ id: 'msg-002' });
+    const thread1 = makeMockThread(msg1);
+    const thread2 = makeMockThread(msg2);
+
+    const origSearch = GmailApp.search;
+    GmailApp.search = () => [thread1, thread2];
+
+    const bankConfig = {
+      banco_nombre: 'BCP',
+      gmail_query: 'from:(test@test.com)',
+      label_procesado: 'ingesta/bcp/ok',
+      label_error: 'ingesta/bcp/error'
+    };
+
+    const emails = GmailService.searchEmails(bankConfig);
+    assert.equal(emails.length, 2);
+    assert.equal(emails[0].getId(), 'msg-001');
+    assert.equal(emails[1].getId(), 'msg-002');
+
+    GmailApp.search = origSearch;
+  });
+});
+
+TestRunner.suite('GmailService — applyLabel', ({ test, assert }) => {
+  test('aplica label al thread del mensaje', () => {
+    const msgOpts = { id: 'msg-001' };
+    const msg = makeMockMessage(msgOpts);
+
+    const origGetLabel = GmailApp.getUserLabelByName;
+    const origCreateLabel = GmailApp.createLabel;
+    const mockLabel = { name: 'ingesta/bcp/ok' };
+
+    GmailApp.getUserLabelByName = () => mockLabel;
+    GmailApp.createLabel = (name) => ({ name });
+
+    GmailService.applyLabel(msg, 'ingesta/bcp/ok');
+    assert.deepEqual(msgOpts._labelAdded, mockLabel);
+
+    GmailApp.getUserLabelByName = origGetLabel;
+    GmailApp.createLabel = origCreateLabel;
+  });
+});

--- a/tests/main-test.gs
+++ b/tests/main-test.gs
@@ -1,0 +1,155 @@
+/**
+ * main-test.gs — Tests de integración del orquestador main.gs
+ */
+
+TestRunner.suite('ParserRegistry — getParser', ({ test, assert }) => {
+  test('retorna BcpParser para clave "bcp"', () => {
+    const parser = ParserRegistry.getParser('bcp');
+    assert.isNotNull(parser);
+    assert.isNotNull(parser.parse);
+  });
+
+  test('retorna InterbankParser para clave "interbank"', () => {
+    const parser = ParserRegistry.getParser('interbank');
+    assert.isNotNull(parser);
+  });
+
+  test('retorna BbvaParser para clave "bbva"', () => {
+    assert.isNotNull(ParserRegistry.getParser('bbva'));
+  });
+
+  test('retorna ScotiabankParser para clave "scotiabank"', () => {
+    assert.isNotNull(ParserRegistry.getParser('scotiabank'));
+  });
+
+  test('retorna YapeParser para clave "yape"', () => {
+    assert.isNotNull(ParserRegistry.getParser('yape'));
+  });
+
+  test('retorna PlinParser para clave "plin"', () => {
+    assert.isNotNull(ParserRegistry.getParser('plin'));
+  });
+
+  test('retorna null para banco desconocido', () => {
+    assert.isNull(ParserRegistry.getParser('banco_desconocido'));
+  });
+});
+
+TestRunner.suite('CONFIG — estructura', ({ test, assert }) => {
+  test('CONFIG tiene todos los bancos definidos', () => {
+    const bancos = Object.keys(CONFIG.bancos);
+    assert.isTrue(bancos.includes('bcp'));
+    assert.isTrue(bancos.includes('interbank'));
+    assert.isTrue(bancos.includes('bbva'));
+    assert.isTrue(bancos.includes('scotiabank'));
+    assert.isTrue(bancos.includes('yape'));
+    assert.isTrue(bancos.includes('plin'));
+  });
+
+  test('cada banco tiene los campos requeridos', () => {
+    const requiredFields = [
+      'enabled', 'banco_nombre', 'gmail_query',
+      'label_procesado', 'label_error', 'parser', 'fallback_ai'
+    ];
+    for (const [key, banco] of Object.entries(CONFIG.bancos)) {
+      for (const field of requiredFields) {
+        if (banco[field] === undefined) {
+          throw new Error(`Banco ${key} falta campo: ${field}`);
+        }
+      }
+    }
+  });
+
+  test('CONFIG tiene las 12 categorías definidas', () => {
+    assert.equal(CONFIG.categorias.length, 12);
+    assert.isTrue(CONFIG.categorias.includes('Supermercado'));
+    assert.isTrue(CONFIG.categorias.includes('Transferencia'));
+    assert.isTrue(CONFIG.categorias.includes('Otro'));
+  });
+
+  test('maxExecutionMs está configurado', () => {
+    assert.isTrue(CONFIG.maxExecutionMs > 0);
+    assert.isTrue(CONFIG.maxExecutionMs <= 360000); // máximo 6 min
+  });
+
+  test('claudeModel está configurado', () => {
+    assert.isNotNull(CONFIG.claudeModel);
+    assert.isTrue(CONFIG.claudeModel.length > 0);
+  });
+});
+
+TestRunner.suite('main — _processEmail integración con mocks', ({ test, assert }) => {
+  // Test de integración: parseo exitoso → categorización → escritura en Sheets
+  test('flujo completo: parseo OK → escribe fila con status "ok"', () => {
+    // Preparar mocks
+    const writtenRows = [];
+    const origAppendRow = SheetsService.appendRow;
+    SheetsService.appendRow = (row) => { writtenRows.push(row); };
+
+    const origApplyLabel = GmailService.applyLabel;
+    const appliedLabels = [];
+    GmailService.applyLabel = (msg, label) => { appliedLabels.push(label); };
+
+    // Mock de ClaudeService.categorize (sin llamada real)
+    const origCategorize = ClaudeService.categorize;
+    ClaudeService.categorize = () => ({ categoria: 'Supermercado', categorized_by_ai: true });
+
+    const mockEmail = {
+      getId: () => 'test-email-id',
+      getSubject: () => 'Consumo BCP',
+      getPlainBody: () => `
+Consumo con tu Tarjeta BCP
+Fecha: 15/01/2026 10:00
+Monto: S/ 89.50
+Comercio: WONG LAS BEGONIAS
+      `,
+      getBody: () => '',
+      getThread: () => ({ addLabel: () => {} })
+    };
+
+    const bcpConfig = CONFIG.bancos.bcp;
+
+    try {
+      const result = _processEmail(mockEmail, 'test-email-id', bcpConfig);
+      assert.isTrue(result.success);
+      assert.equal(writtenRows.length, 1);
+      assert.equal(writtenRows[0].status, 'ok');
+      assert.equal(writtenRows[0].banco, 'BCP');
+      assert.equal(writtenRows[0].email_id, 'test-email-id');
+    } finally {
+      SheetsService.appendRow = origAppendRow;
+      GmailService.applyLabel = origApplyLabel;
+      ClaudeService.categorize = origCategorize;
+    }
+  });
+
+  test('flujo: parseo fallido → registra status "parse_error"', () => {
+    const writtenRows = [];
+    const origAppendRow = SheetsService.appendRow;
+    SheetsService.appendRow = (row) => { writtenRows.push(row); };
+
+    const origApplyLabel = GmailService.applyLabel;
+    GmailService.applyLabel = () => {};
+
+    const mockEmail = {
+      getId: () => 'test-email-bad',
+      getSubject: () => 'Email sin datos bancarios',
+      getPlainBody: () => 'Este email no tiene datos de transacción bancaria',
+      getBody: () => '',
+      getThread: () => ({ addLabel: () => {} })
+    };
+
+    // BCP con fallback_ai=false para simplificar el test
+    const testConfig = { ...CONFIG.bancos.bcp, fallback_ai: false };
+
+    try {
+      const result = _processEmail(mockEmail, 'test-email-bad', testConfig);
+      assert.isFalse(result.success);
+      assert.equal(writtenRows.length, 1);
+      assert.equal(writtenRows[0].status, 'parse_error');
+    } finally {
+      SheetsService.appendRow = origAppendRow;
+      GmailService.applyLabel = origApplyLabel;
+    }
+  });
+});

--- a/tests/parsers-test.gs
+++ b/tests/parsers-test.gs
@@ -277,3 +277,85 @@ TestRunner.suite('PlinParser — casos de error', ({ test, assert }) => {
     assert.isNull(PlinParser.parse(null));
   });
 });
+
+// ── Diners Club ───────────────────────────────────────────────────────────────
+
+const DINERS_EMAIL_OK = `
+Notificación de Compras Diners Club
+
+Estimado cliente,
+Se realizó una compra con su tarjeta Diners Club.
+
+Fecha: 05/04/2026 13:45
+Monto: S/ 210.00
+Comercio: SAGA FALABELLA JOCKEY
+Tarjeta: **** 3456
+
+Si no reconoce esta operación, contáctenos al 615-1111.
+`;
+
+const DINERS_EMAIL_CONSUMO = `
+Aviso de Consumo Diners Club
+
+Hola,
+Se procesó un consumo con su tarjeta Diners en línea.
+
+Fecha: 01/04/2026
+Importe: S/ 75.50
+Establecimiento: AMAZON.COM
+`;
+
+const DINERS_EMAIL_SIN_MONTO = `
+Aviso Diners Club
+
+Estimado cliente,
+Fecha: 05/04/2026
+(monto no disponible)
+`;
+
+TestRunner.suite('DinersParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto correctamente', () => {
+    const result = DinersParser.parse(DINERS_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 210.00, 0.001);
+  });
+
+  test('extrae fecha en formato YYYY-MM-DD', () => {
+    const result = DinersParser.parse(DINERS_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-04-05');
+  });
+
+  test('extrae comercio', () => {
+    const result = DinersParser.parse(DINERS_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.isTrue(result.comercio.length > 0);
+  });
+
+  test('incluye raw en el resultado', () => {
+    const result = DinersParser.parse(DINERS_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.raw, DINERS_EMAIL_OK);
+  });
+
+  test('parsea email con Importe y Establecimiento', () => {
+    const result = DinersParser.parse(DINERS_EMAIL_CONSUMO);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 75.50, 0.001);
+    assert.equal(result.fecha, '2026-04-01');
+  });
+});
+
+TestRunner.suite('DinersParser — casos de error', ({ test, assert }) => {
+  test('retorna null si no hay monto', () => {
+    assert.isNull(DinersParser.parse(DINERS_EMAIL_SIN_MONTO));
+  });
+
+  test('retorna null para string vacío', () => {
+    assert.isNull(DinersParser.parse(''));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(DinersParser.parse(null));
+  });
+});

--- a/tests/parsers-test.gs
+++ b/tests/parsers-test.gs
@@ -1,0 +1,279 @@
+/**
+ * parsers-test.gs — Tests unitarios para los 6 parsers con fixtures de email
+ */
+
+// ── BCP ──────────────────────────────────────────────────────────────────────
+
+const BCP_EMAIL_OK = `
+Notificación de consumo BCP
+
+Hola Juan,
+Realizaste un consumo con tu Tarjeta de Débito BCP.
+
+Fecha: 15/01/2026 10:35
+Monto: S/ 89.50
+Comercio: WONG LAS BEGONIAS
+Número de tarjeta: **** 4521
+
+Si no reconoces esta operación, llámanos al 311-9898.
+`;
+
+const BCP_EMAIL_SIN_MONTO = `
+Notificación de consumo BCP
+
+Hola Juan,
+Realizaste un consumo con tu Tarjeta BCP.
+
+Fecha: 15/01/2026
+(monto no disponible en este email)
+`;
+
+TestRunner.suite('BcpParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto correctamente', () => {
+    const result = BcpParser.parse(BCP_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 89.50, 0.001);
+  });
+
+  test('extrae fecha en formato YYYY-MM-DD', () => {
+    const result = BcpParser.parse(BCP_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-01-15');
+  });
+
+  test('extrae comercio', () => {
+    const result = BcpParser.parse(BCP_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.isNotNull(result.comercio);
+    assert.isTrue(result.comercio.length > 0);
+  });
+
+  test('incluye raw en el resultado', () => {
+    const result = BcpParser.parse(BCP_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.raw, BCP_EMAIL_OK);
+  });
+});
+
+TestRunner.suite('BcpParser — casos de error', ({ test, assert }) => {
+  test('retorna null si no hay monto', () => {
+    assert.isNull(BcpParser.parse(BCP_EMAIL_SIN_MONTO));
+  });
+
+  test('retorna null para string vacío', () => {
+    assert.isNull(BcpParser.parse(''));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(BcpParser.parse(null));
+  });
+});
+
+// ── Interbank ─────────────────────────────────────────────────────────────────
+
+const INTERBANK_EMAIL_OK = `
+Alerta de consumo Interbank
+
+Se realizó un consumo con tu tarjeta Interbank:
+
+Fecha: 20/02/2026 14:22
+Importe: S/ 45.00
+Establecimiento: METRO SURCO
+Tarjeta: **** 7890
+`;
+
+const INTERBANK_EMAIL_SIN_FECHA = `
+Alerta de consumo Interbank
+
+Se realizó un consumo con tu tarjeta Interbank:
+Importe: S/ 45.00
+Establecimiento: METRO SURCO
+`;
+
+TestRunner.suite('InterbankParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto', () => {
+    const result = InterbankParser.parse(INTERBANK_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 45.00, 0.001);
+  });
+
+  test('extrae fecha', () => {
+    const result = InterbankParser.parse(INTERBANK_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-02-20');
+  });
+});
+
+TestRunner.suite('InterbankParser — casos de error', ({ test, assert }) => {
+  test('retorna null si no hay fecha', () => {
+    assert.isNull(InterbankParser.parse(INTERBANK_EMAIL_SIN_FECHA));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(InterbankParser.parse(null));
+  });
+});
+
+// ── BBVA ──────────────────────────────────────────────────────────────────────
+
+const BBVA_EMAIL_OK = `
+Alerta de compra BBVA
+
+Hola,
+Se realizó una compra con tu tarjeta BBVA.
+
+Fecha: 10/03/2026
+Monto: S/ 120.00
+Comercio: RIPLEY JOCKEY PLAZA
+`;
+
+TestRunner.suite('BbvaParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto', () => {
+    const result = BbvaParser.parse(BBVA_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 120.00, 0.001);
+  });
+
+  test('extrae fecha', () => {
+    const result = BbvaParser.parse(BBVA_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-03-10');
+  });
+});
+
+TestRunner.suite('BbvaParser — casos de error', ({ test, assert }) => {
+  test('retorna null para cuerpo sin monto ni fecha', () => {
+    assert.isNull(BbvaParser.parse('Email sin datos de transacción'));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(BbvaParser.parse(null));
+  });
+});
+
+// ── Scotiabank ────────────────────────────────────────────────────────────────
+
+const SCOTIABANK_EMAIL_OK = `
+Notificación de consumo Scotiabank
+
+Estimado cliente,
+Se realizó un consumo con su tarjeta Scotiabank:
+
+Fecha: 05/04/2026 09:15
+Monto: S/ 55.00
+Establecimiento: TOTTUS SAN BORJA
+`;
+
+TestRunner.suite('ScotiabankParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto', () => {
+    const result = ScotiabankParser.parse(SCOTIABANK_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 55.00, 0.001);
+  });
+
+  test('extrae fecha', () => {
+    const result = ScotiabankParser.parse(SCOTIABANK_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-04-05');
+  });
+});
+
+TestRunner.suite('ScotiabankParser — casos de error', ({ test, assert }) => {
+  test('retorna null para cuerpo vacío', () => {
+    assert.isNull(ScotiabankParser.parse(''));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(ScotiabankParser.parse(null));
+  });
+});
+
+// ── Yape ──────────────────────────────────────────────────────────────────────
+
+const YAPE_EMAIL_OK = `
+¡Pago exitoso con Yape!
+
+Pagaste a María García por S/ 30.00
+
+Fecha: 12/04/2026 11:00
+Operación: #YP-20260412-001
+
+Gracias por usar Yape.
+`;
+
+const YAPE_EMAIL_SIN_DESTINATARIO = `
+¡Pago exitoso con Yape!
+
+Enviaste S/ 30.00
+
+Fecha: 12/04/2026
+`;
+
+TestRunner.suite('YapeParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto', () => {
+    const result = YapeParser.parse(YAPE_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 30.00, 0.001);
+  });
+
+  test('extrae fecha', () => {
+    const result = YapeParser.parse(YAPE_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-04-12');
+  });
+
+  test('usa "Desconocido" si no extrae destinatario', () => {
+    const result = YapeParser.parse(YAPE_EMAIL_SIN_DESTINATARIO);
+    // Puede parsear monto y fecha, pero comercio será Desconocido
+    if (result) {
+      assert.isTrue(result.comercio === 'DESCONOCIDO' || result.comercio.length > 0);
+    }
+  });
+});
+
+TestRunner.suite('YapeParser — casos de error', ({ test, assert }) => {
+  test('retorna null para cuerpo sin monto', () => {
+    assert.isNull(YapeParser.parse('Email de Yape sin datos de pago'));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(YapeParser.parse(null));
+  });
+});
+
+// ── Plin ──────────────────────────────────────────────────────────────────────
+
+const PLIN_EMAIL_OK = `
+¡Transferencia exitosa con Plin!
+
+Enviaste dinero a Carlos López por S/ 50.00
+
+Fecha: 15/04/2026 16:30
+Operación: #PL-20260415-002
+
+Tu pago fue procesado correctamente.
+`;
+
+TestRunner.suite('PlinParser — parse exitoso', ({ test, assert }) => {
+  test('extrae monto', () => {
+    const result = PlinParser.parse(PLIN_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.closeTo(result.monto, 50.00, 0.001);
+  });
+
+  test('extrae fecha', () => {
+    const result = PlinParser.parse(PLIN_EMAIL_OK);
+    assert.isNotNull(result);
+    assert.equal(result.fecha, '2026-04-15');
+  });
+});
+
+TestRunner.suite('PlinParser — casos de error', ({ test, assert }) => {
+  test('retorna null para cuerpo sin monto ni fecha', () => {
+    assert.isNull(PlinParser.parse('Email de Plin sin datos'));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(PlinParser.parse(null));
+  });
+});

--- a/tests/sheets-service-test.gs
+++ b/tests/sheets-service-test.gs
@@ -1,0 +1,167 @@
+/**
+ * sheets-service-test.gs — Tests para SheetsService con mock de SpreadsheetApp
+ */
+
+/**
+ * Crea un mock de la hoja de cálculo con datos dados.
+ * @param {Array[]} rows - Filas de datos (sin header)
+ * @returns {Object} Mock de Sheet
+ */
+function makeMockSheet(rows) {
+  const allRows = [SHEET_HEADERS, ...rows];
+  const appendedRows = [];
+
+  return {
+    getLastRow: () => allRows.length,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () => {
+        const result = [];
+        for (let r = row - 1; r < row - 1 + numRows; r++) {
+          const rowData = allRows[r] || [];
+          const colData = [];
+          for (let c = col - 1; c < col - 1 + numCols; c++) {
+            colData.push(rowData[c] !== undefined ? rowData[c] : '');
+          }
+          result.push(colData);
+        }
+        return result;
+      }
+    }),
+    appendRow: (row) => { appendedRows.push(row); allRows.push(row); },
+    setFontWeight: () => {},
+    _appendedRows: appendedRows
+  };
+}
+
+/**
+ * Inyecta un mock de SpreadsheetApp para la duración de fn().
+ */
+function withMockSpreadsheet(mockSheet, fn) {
+  const original = SpreadsheetApp.openById;
+  SpreadsheetApp.openById = () => ({
+    getSheetByName: () => mockSheet,
+    insertSheet: () => mockSheet
+  });
+  try {
+    fn(mockSheet);
+  } finally {
+    SpreadsheetApp.openById = original;
+  }
+}
+
+TestRunner.suite('SheetsService — getProcessedEmailIds', ({ test, assert }) => {
+  test('retorna Set vacío cuando la hoja tiene solo headers', () => {
+    const sheet = makeMockSheet([]);
+    withMockSpreadsheet(sheet, () => {
+      const ids = SheetsService.getProcessedEmailIds();
+      assert.equal(ids.size, 0);
+    });
+  });
+
+  test('retorna IDs de emails ya procesados', () => {
+    const sheet = makeMockSheet([
+      ['2026-01-15', 89.50, 'WONG', 'BCP', 'usuario1', 'Supermercado',
+       true, false, 'ok', 'email-id-001', '2026-01-15T10:00:00-05:00'],
+      ['2026-01-16', 45.00, 'METRO', 'Interbank', 'usuario1', 'Supermercado',
+       true, false, 'ok', 'email-id-002', '2026-01-16T11:00:00-05:00']
+    ]);
+    withMockSpreadsheet(sheet, () => {
+      const ids = SheetsService.getProcessedEmailIds();
+      assert.equal(ids.size, 2);
+      assert.isTrue(ids.has('email-id-001'));
+      assert.isTrue(ids.has('email-id-002'));
+      assert.isFalse(ids.has('email-id-999'));
+    });
+  });
+});
+
+TestRunner.suite('SheetsService — appendRow', ({ test, assert }) => {
+  test('escribe una fila con todos los campos correctos', () => {
+    const sheet = makeMockSheet([]);
+    withMockSpreadsheet(sheet, () => {
+      SheetsService.appendRow({
+        fecha: '2026-01-15',
+        monto: 89.50,
+        comercio: 'WONG LAS BEGONIAS',
+        banco: 'BCP',
+        usuario: 'usuario1',
+        categoria: 'Supermercado',
+        categorized_by_ai: true,
+        parsed_by_ai: false,
+        status: 'ok',
+        email_id: 'email-id-123',
+        timestamp_ingesta: '2026-01-15T10:00:00-05:00'
+      });
+
+      const written = sheet._appendedRows[0];
+      assert.equal(written[0], '2026-01-15');      // fecha
+      assert.equal(written[1], 89.50);              // monto
+      assert.equal(written[2], 'WONG LAS BEGONIAS'); // comercio
+      assert.equal(written[3], 'BCP');               // banco
+      assert.equal(written[4], 'usuario1');           // usuario
+      assert.equal(written[5], 'Supermercado');       // categoria
+      assert.isTrue(written[6]);                     // categorized_by_ai
+      assert.isFalse(written[7]);                    // parsed_by_ai
+      assert.equal(written[8], 'ok');                // status
+      assert.equal(written[9], 'email-id-123');      // email_id
+    });
+  });
+
+  test('usa "Sin categorizar" como default de categoria', () => {
+    const sheet = makeMockSheet([]);
+    withMockSpreadsheet(sheet, () => {
+      SheetsService.appendRow({
+        fecha: '2026-01-15',
+        monto: 89.50,
+        comercio: 'WONG',
+        banco: 'BCP',
+        email_id: 'test-id'
+      });
+      const written = sheet._appendedRows[0];
+      assert.equal(written[5], 'Sin categorizar');
+    });
+  });
+
+  test('usa "ok" como default de status', () => {
+    const sheet = makeMockSheet([]);
+    withMockSpreadsheet(sheet, () => {
+      SheetsService.appendRow({
+        fecha: '2026-01-15',
+        monto: 89.50,
+        comercio: 'WONG',
+        banco: 'BCP',
+        email_id: 'test-id'
+      });
+      const written = sheet._appendedRows[0];
+      assert.equal(written[8], 'ok');
+    });
+  });
+});
+
+TestRunner.suite('SheetsService — ensureHeaders', ({ test, assert }) => {
+  test('crea headers cuando la hoja está vacía', () => {
+    const emptySheet = {
+      getLastRow: () => 0,
+      getRange: () => ({ setFontWeight: () => {} }),
+      appendRow: (row) => { emptySheet._headerRow = row; }
+    };
+    withMockSpreadsheet(emptySheet, () => {
+      SheetsService.ensureHeaders();
+      assert.isNotNull(emptySheet._headerRow);
+      assert.equal(emptySheet._headerRow[0], 'fecha');
+      assert.equal(emptySheet._headerRow[9], 'email_id');
+    });
+  });
+
+  test('no modifica hoja que ya tiene headers', () => {
+    let appendCalled = false;
+    const sheetWithHeaders = {
+      getLastRow: () => 5,
+      appendRow: () => { appendCalled = true; }
+    };
+    withMockSpreadsheet(sheetWithHeaders, () => {
+      SheetsService.ensureHeaders();
+      assert.isFalse(appendCalled);
+    });
+  });
+});

--- a/tests/test-runner.gs
+++ b/tests/test-runner.gs
@@ -1,0 +1,124 @@
+/**
+ * test-runner.gs — Framework minimalista de testing para Google Apps Script
+ *
+ * Uso:
+ *   runAllTests()  — ejecuta todos los test suites registrados
+ *
+ * En Apps Script no hay npm ni jest, así que usamos console.log para reportar.
+ */
+
+const TestRunner = {
+  _suites: [],
+  _passed: 0,
+  _failed: 0,
+
+  /**
+   * Registra un test suite.
+   * @param {string} name
+   * @param {Function} fn
+   */
+  suite(name, fn) {
+    this._suites.push({ name, fn });
+  },
+
+  /**
+   * Ejecuta todos los suites registrados.
+   */
+  run() {
+    this._passed = 0;
+    this._failed = 0;
+    console.log('=== TEST RUN START ===');
+
+    for (const suite of this._suites) {
+      console.log(`\n--- Suite: ${suite.name} ---`);
+      try {
+        suite.fn(this._makeContext());
+      } catch (e) {
+        console.log(`  [SUITE ERROR] ${suite.name}: ${e.message}`);
+        this._failed++;
+      }
+    }
+
+    console.log(`\n=== RESULTS: ${this._passed} passed, ${this._failed} failed ===`);
+    return this._failed === 0;
+  },
+
+  _makeContext() {
+    const runner = this;
+    return {
+      /**
+       * @param {string} description
+       * @param {Function} fn
+       */
+      test(description, fn) {
+        try {
+          fn();
+          console.log(`  ✓ ${description}`);
+          runner._passed++;
+        } catch (e) {
+          console.log(`  ✗ ${description}: ${e.message}`);
+          runner._failed++;
+        }
+      },
+
+      assert: {
+        equal(actual, expected, msg) {
+          if (actual !== expected) {
+            throw new Error(
+              `${msg || 'assert.equal'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+            );
+          }
+        },
+        deepEqual(actual, expected, msg) {
+          const a = JSON.stringify(actual);
+          const e = JSON.stringify(expected);
+          if (a !== e) {
+            throw new Error(
+              `${msg || 'assert.deepEqual'}: expected ${e}, got ${a}`
+            );
+          }
+        },
+        isNull(actual, msg) {
+          if (actual !== null) {
+            throw new Error(
+              `${msg || 'assert.isNull'}: expected null, got ${JSON.stringify(actual)}`
+            );
+          }
+        },
+        isNotNull(actual, msg) {
+          if (actual === null || actual === undefined) {
+            throw new Error(
+              `${msg || 'assert.isNotNull'}: expected non-null, got ${JSON.stringify(actual)}`
+            );
+          }
+        },
+        isTrue(actual, msg) {
+          if (actual !== true) {
+            throw new Error(`${msg || 'assert.isTrue'}: expected true, got ${JSON.stringify(actual)}`);
+          }
+        },
+        isFalse(actual, msg) {
+          if (actual !== false) {
+            throw new Error(`${msg || 'assert.isFalse'}: expected false, got ${JSON.stringify(actual)}`);
+          }
+        },
+        closeTo(actual, expected, delta, msg) {
+          if (Math.abs(actual - expected) > delta) {
+            throw new Error(
+              `${msg || 'assert.closeTo'}: expected ${expected} ±${delta}, got ${actual}`
+            );
+          }
+        }
+      }
+    };
+  }
+};
+
+/**
+ * Función principal que ejecuta todos los tests.
+ * Registrar en Apps Script como función ejecutable.
+ */
+function runAllTests() {
+  // Los suites se registran en sus propios archivos al cargar
+  return TestRunner.run();
+}

--- a/tests/utils-test.gs
+++ b/tests/utils-test.gs
@@ -1,0 +1,145 @@
+/**
+ * utils-test.gs — Tests unitarios para utils.gs
+ */
+
+TestRunner.suite('utils — parseDate', ({ test, assert }) => {
+  test('parsea formato DD/MM/YYYY', () => {
+    assert.equal(parseDate('15/01/2026'), '2026-01-15');
+  });
+
+  test('parsea formato DD-MM-YYYY', () => {
+    assert.equal(parseDate('15-01-2026'), '2026-01-15');
+  });
+
+  test('parsea formato YYYY-MM-DD (pass-through)', () => {
+    assert.equal(parseDate('2026-01-15'), '2026-01-15');
+  });
+
+  test('parsea formato textual "15 de enero de 2026"', () => {
+    assert.equal(parseDate('15 de enero de 2026'), '2026-01-15');
+  });
+
+  test('parsea formato textual "5 de marzo 2026" (sin "de" final)', () => {
+    assert.equal(parseDate('5 de marzo 2026'), '2026-03-05');
+  });
+
+  test('parsea formato DD/MM/YY con año 2-dígitos', () => {
+    assert.equal(parseDate('15/01/26'), '2026-01-15');
+  });
+
+  test('retorna null para string vacío', () => {
+    assert.isNull(parseDate(''));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(parseDate(null));
+  });
+
+  test('retorna null para formato no reconocido', () => {
+    assert.isNull(parseDate('no es una fecha'));
+  });
+});
+
+TestRunner.suite('utils — parseAmount', ({ test, assert }) => {
+  test('parsea "S/ 150.00"', () => {
+    assert.equal(parseAmount('S/ 150.00'), 150);
+  });
+
+  test('parsea "S/150.00" (sin espacio)', () => {
+    assert.equal(parseAmount('S/150.00'), 150);
+  });
+
+  test('parsea "1,234.56" (formato americano con miles)', () => {
+    assert.closeTo(parseAmount('1,234.56'), 1234.56, 0.001);
+  });
+
+  test('parsea "1.234,56" (formato europeo con miles)', () => {
+    assert.closeTo(parseAmount('1.234,56'), 1234.56, 0.001);
+  });
+
+  test('parsea "S/ 1,234.56"', () => {
+    assert.closeTo(parseAmount('S/ 1,234.56'), 1234.56, 0.001);
+  });
+
+  test('retorna null para string vacío', () => {
+    assert.isNull(parseAmount(''));
+  });
+
+  test('retorna null para null', () => {
+    assert.isNull(parseAmount(null));
+  });
+
+  test('retorna null para monto 0', () => {
+    assert.isNull(parseAmount('0.00'));
+  });
+
+  test('retorna null para texto no numérico', () => {
+    assert.isNull(parseAmount('no es monto'));
+  });
+});
+
+TestRunner.suite('utils — normalizeText', ({ test, assert }) => {
+  test('convierte a mayúsculas', () => {
+    assert.equal(normalizeText('wong las begonias'), 'WONG LAS BEGONIAS');
+  });
+
+  test('elimina espacios múltiples', () => {
+    assert.equal(normalizeText('WONG   LAS  BEGONIAS'), 'WONG LAS BEGONIAS');
+  });
+
+  test('hace trim', () => {
+    assert.equal(normalizeText('  WONG  '), 'WONG');
+  });
+
+  test('retorna string vacío para null', () => {
+    assert.equal(normalizeText(null), '');
+  });
+});
+
+TestRunner.suite('utils — sanitizeForPrompt', ({ test, assert }) => {
+  test('trunca texto largo al máximo configurado', () => {
+    const longText = 'a'.repeat(4000);
+    const result = sanitizeForPrompt(longText, 3000);
+    assert.isTrue(result.length <= 3000 + 20); // +20 por el "[... truncado]"
+    assert.isTrue(result.includes('[... truncado]'));
+  });
+
+  test('no modifica texto corto', () => {
+    const shortText = 'Texto corto normal';
+    assert.equal(sanitizeForPrompt(shortText, 3000), shortText);
+  });
+
+  test('elimina caracteres de control', () => {
+    const withControl = 'Texto\x00con\x01control';
+    const result = sanitizeForPrompt(withControl, 3000);
+    assert.isFalse(result.includes('\x00'));
+    assert.isFalse(result.includes('\x01'));
+  });
+
+  test('retorna string vacío para null', () => {
+    assert.equal(sanitizeForPrompt(null, 3000), '');
+  });
+});
+
+TestRunner.suite('utils — htmlToText', ({ test, assert }) => {
+  test('convierte <br> a salto de línea', () => {
+    const html = 'Línea 1<br>Línea 2';
+    const result = htmlToText(html);
+    assert.isTrue(result.includes('\n') || result.includes('Línea 1'));
+  });
+
+  test('remueve tags HTML', () => {
+    const html = '<b>Texto</b> normal <span>aquí</span>';
+    const result = htmlToText(html);
+    assert.isFalse(result.includes('<b>'));
+    assert.isTrue(result.includes('Texto'));
+    assert.isTrue(result.includes('normal'));
+  });
+
+  test('decodifica entidades HTML comunes', () => {
+    const html = 'S/&nbsp;150.00 &amp; más';
+    const result = htmlToText(html);
+    assert.isTrue(result.includes('S/'));
+    assert.isTrue(result.includes('&'));
+  });
+});


### PR DESCRIPTION
Implementa el pipeline completo de ingesta de emails de gasto para BCP, Interbank, BBVA, Scotiabank, Yape y Plin en Google Apps Script.

## Requirements implementados

- US-01 a US-05: Ingesta automática por banco (regex + fallback Claude API)
- US-06: Vista consolidada en Google Sheets (11 columnas)
- US-07: Categorización automática vía Claude API (claude-haiku-4-5)
- US-08: Trigger diario a las 7 AM hora de Lima

## Design decisions implementadas

- DT-001: Un script por usuario
- DT-002: CONFIG como objeto literal + PropertiesService para secretos
- DT-003: Parser Protocol común para todos los parsers
- DT-004: ClaudeService con prompts separados (categorize + parseWithAI)
- DT-005: Deduplicación dual Gmail labels + email_id en Sheets
- DT-006: Fail-open por email
- DT-007: Checkpoint ante límite de 6 min

## Archivos nuevos

13 módulos en src/ + 7 archivos de tests + appsscript.json + tasks.md

Closes #4

Generated with [Claude Code](https://claude.ai/code)