### PR TITLE
feat: implement SDD Alt 2 — deterministic branch + Draft PR model (#10)

### DIFF
--- a/.github/workflows/sdd-feature.yml
+++ b/.github/workflows/sdd-feature.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
 
 jobs:
+  # Phase 1: Requirements — triggered on issue open/assign
+  # Creates deterministic branch sdd/issue-N, writes requirements.md, opens Draft PR
   sdd-requirements:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
@@ -20,7 +22,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GIT_HUB_PAT }}
-          fetch-depth: 1                    
+          fetch-depth: 0
+
+      - name: Create deterministic SDD branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="sdd/issue-${{ github.event.issue.number }}"
+          # Reuse existing branch or create new one from main
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" > /dev/null 2>&1; then
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH" --rebase
+          else
+            git checkout -b "$BRANCH"
+            git push -u origin "$BRANCH"
+          fi
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -29,7 +46,6 @@ jobs:
             actions: read
           claude_args: '--allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue comment:*),Read,Write,Edit" --permission-mode acceptEdits'
           trigger_phrase: "@claude"
-          branch_prefix: "sdd/"
           use_sticky_comment: true
           classify_inline_comments: true
           track_progress: true
@@ -44,21 +60,69 @@ jobs:
             Título: "${{ github.event.issue.title }}"
             Descripción: ${{ github.event.issue.body }}
 
-            Luego ejecuta estos pasos en orden:
+            Estás en la rama sdd/issue-${{ github.event.issue.number }}. No crees una rama nueva.
 
-            1. Crea el directorio: .specs/${{ github.event.issue.number }}-feature/
-            
-            2. Crea el archivo .specs/${{ github.event.issue.number }}-feature/requirements.md con:
+            Ejecuta estos pasos en orden:
+
+            1. Crea el directorio .specs/${{ github.event.issue.number }}-feature/ (si no existe)
+
+            2. Crea (o actualiza) .specs/${{ github.event.issue.number }}-feature/requirements.md con:
+               - Frontmatter con Status: Draft
                - User stories en formato "As a [usuario], I want [acción] so that [beneficio]"
                - Criterios de aceptación GIVEN/WHEN/THEN por cada story
                - Restricciones técnicas alineadas al ADR-001
                - Sección fuera de alcance
 
-            3. Comenta en el issue #${{ github.event.issue.number }}:
-               "✅ requirements.md generado. Revisar en .specs/${{ github.event.issue.number }}-feature/requirements.md
-               Responder con @claude-approve-requirements para continuar con design.md"
+            3. Commitea y sube los cambios:
+               git add .specs/${{ github.event.issue.number }}-feature/
+               git commit -m "docs: add requirements.md for issue #${{ github.event.issue.number }}"
+               git push origin sdd/issue-${{ github.event.issue.number }}
 
+            4. Comenta en el issue #${{ github.event.issue.number }}:
+               "✅ requirements.md generado en la rama sdd/issue-${{ github.event.issue.number }}.
+               Un Draft PR se abrirá en segundos con el diff completo.
 
+               Para **corregir**: comenta en el PR del ciclo SDD con @claude + tu feedback.
+               Para **aprobar** y avanzar al diseño: responde aquí con @claude-approve-requirements"
+
+      - name: Create Draft PR
+        env:
+          GH_TOKEN: ${{ secrets.GIT_HUB_PAT }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          BRANCH="sdd/issue-${ISSUE_NUMBER}"
+          PR_EXISTS=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+          if [ "$PR_EXISTS" -eq "0" ]; then
+            cat > /tmp/pr-body.md << EOF
+## Ciclo SDD — Issue #${ISSUE_NUMBER}
+
+Estado: 🔵 **REQUIREMENTS IN REVIEW**
+
+### Artefactos
+- [ ] \`.specs/${ISSUE_NUMBER}-feature/requirements.md\` — Draft
+- [ ] \`.specs/${ISSUE_NUMBER}-feature/design.md\`
+- [ ] \`.specs/${ISSUE_NUMBER}-feature/tasks.md\` + implementación
+
+### Flujo de trabajo
+- **Correcciones en cualquier fase**: comenta en este PR con \`@claude [feedback]\`
+- **Aprobar requirements**: comenta en issue #${ISSUE_NUMBER} con \`@claude-approve-requirements\`
+- **Aprobar design**: comenta en issue #${ISSUE_NUMBER} con \`@claude-approve-design\`
+
+Resuelve #${ISSUE_NUMBER}
+
+Generated with [Claude Code](https://claude.ai/code)
+EOF
+            gh pr create \
+              --draft \
+              --base main \
+              --head "$BRANCH" \
+              --title "feat: Issue #${ISSUE_NUMBER} — ${ISSUE_TITLE}" \
+              --body-file /tmp/pr-body.md || echo "Warning: PR creation failed, may already exist"
+          fi
+
+  # Phase 2: Design — triggered by @claude-approve-requirements comment in the issue
+  # Checks out sdd/issue-N, marks requirements.md as Approved, generates design.md
   sdd-design:
     if: |
       github.event_name == 'issue_comment' &&
@@ -72,30 +136,51 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GIT_HUB_PAT }}
+          ref: sdd/issue-${{ github.event.issue.number }}
           fetch-depth: 1
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GIT_HUB_PAT }}
-          branch_prefix: "sdd/"
+          claude_args: '--allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh issue comment:*),Read,Write,Edit" --permission-mode acceptEdits'
           use_sticky_comment: true
           classify_inline_comments: true
           track_progress: true
           include_fix_links: true
           prompt: |
             Requirements aprobados para issue #${{ github.event.issue.number }}.
-            1. Lee .specs/${{ github.event.issue.number }}-feature/requirements.md
-            
-            2. Genera en .specs/${{ github.event.issue.number }}-feature/design.md con:
-            - Arquitectura propuesta (componentes, capas)
-            - Diagrama de secuencia en Mermaid
-            - Decisiones técnicas (ADRs) con justificación
-            - Impacto en codebase existente
-            
-            3. Comenta en el issue #${{ github.event.issue.number }}:
-               "✅ design.md generado. Revisar en .specs/${{ github.event.issue.number }}-feature/design.md
-               Responder con @claude-approve-design para continuar con la implementación"
+            Estás en la rama sdd/issue-${{ github.event.issue.number }}. No crees una rama nueva.
 
+            0. Actualiza el campo Status en .specs/${{ github.event.issue.number }}-feature/requirements.md
+               de "Draft" o "Revised" a "Approved". Commitea ese cambio:
+               git add .specs/${{ github.event.issue.number }}-feature/requirements.md
+               git commit -m "docs: approve requirements.md for issue #${{ github.event.issue.number }}"
+               git push origin sdd/issue-${{ github.event.issue.number }}
+
+            1. Lee .specs/${{ github.event.issue.number }}-feature/requirements.md
+
+            2. Crea .specs/${{ github.event.issue.number }}-feature/design.md con:
+               - Frontmatter con Status: Draft
+               - Arquitectura propuesta (componentes, capas)
+               - Diagrama de secuencia en Mermaid
+               - Decisiones técnicas (ADRs) con justificación
+               - Impacto en codebase existente
+
+            3. Commitea y sube los cambios:
+               git add .specs/${{ github.event.issue.number }}-feature/design.md
+               git commit -m "docs: add design.md for issue #${{ github.event.issue.number }}"
+               git push origin sdd/issue-${{ github.event.issue.number }}
+
+            4. Comenta en el issue #${{ github.event.issue.number }}:
+               "✅ design.md generado en la rama sdd/issue-${{ github.event.issue.number }}.
+               Revisar el diff en el PR del ciclo SDD.
+
+               Para **corregir**: comenta en el PR con @claude + tu feedback.
+               Para **aprobar** y avanzar a implementación: responde aquí con @claude-approve-design"
+
+  # Phase 3: Implementation — triggered by @claude-approve-design comment in the issue
+  # Checks out sdd/issue-N, marks design.md as Approved, implements code, converts Draft PR to Ready
   sdd-implement:
     if: |
       github.event_name == 'issue_comment' &&
@@ -109,23 +194,50 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GIT_HUB_PAT }}
+          ref: sdd/issue-${{ github.event.issue.number }}
           fetch-depth: 1
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GIT_HUB_PAT }}
-          branch_prefix: "sdd/"
+          claude_args: '--allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh issue comment:*),Read,Write,Edit" --permission-mode acceptEdits'
           use_sticky_comment: true
           classify_inline_comments: true
           track_progress: true
           include_fix_links: true
           prompt: |
-            Design aprobado. Lee requirements.md y design.md en
-            .specs/${{ github.event.issue.number }}-feature/
-            
-            1. Genera .specs/${{ github.event.issue.number }}-feature/tasks.md con tareas secuenciadas y sus dependencias
-            2. Implementa cada task respetando el design
-            3. Escribe tests unitarios por cada componente nuevo
-            4. Crea un PR vinculado al issue #${{ github.event.issue.number }}
-               con título: "feat: [descripción del issue]"
-               Body: resumen de requirements + design decisions + tasks completadas
+            Design aprobado para issue #${{ github.event.issue.number }}.
+            Estás en la rama sdd/issue-${{ github.event.issue.number }}. No crees una rama nueva.
+
+            0. Actualiza el campo Status en .specs/${{ github.event.issue.number }}-feature/design.md
+               de "Draft" o "Revised" a "Approved". Commitea ese cambio:
+               git add .specs/${{ github.event.issue.number }}-feature/design.md
+               git commit -m "docs: approve design.md for issue #${{ github.event.issue.number }}"
+               git push origin sdd/issue-${{ github.event.issue.number }}
+
+            1. Lee requirements.md y design.md en .specs/${{ github.event.issue.number }}-feature/
+
+            2. Genera .specs/${{ github.event.issue.number }}-feature/tasks.md con tareas secuenciadas y sus dependencias
+            3. Implementa cada task respetando el design
+            4. Escribe tests unitarios por cada componente nuevo
+            5. Commitea los cambios incrementalmente con mensajes descriptivos:
+               git add <archivos>
+               git commit -m "feat: [descripción] for issue #${{ github.event.issue.number }}"
+               git push origin sdd/issue-${{ github.event.issue.number }}
+            6. Comenta en el issue #${{ github.event.issue.number }} que la implementación está completa
+               y que el PR está listo para code review
+
+      - name: Mark PR as Ready for Review
+        env:
+          GH_TOKEN: ${{ secrets.GIT_HUB_PAT }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="sdd/issue-${ISSUE_NUMBER}"
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            gh pr ready "$PR_NUMBER" 2>/dev/null || true
+            echo "PR #${PR_NUMBER} marked as ready for review"
+          else
+            echo "No open draft PR found for branch $BRANCH"
+          fi

--- a/.specs/10-feature/design.md
+++ b/.specs/10-feature/design.md
@@ -278,7 +278,7 @@ sequenceDiagram
 
 **Justificación:** `claude-code-action` ya provee:
 1. Manejo de contexto del repositorio (checkout, herramientas de lectura/escritura)
-2. Gestión de ramas (`branch_prefix`)
+2. Gestión de ramas (`branch_prefix`) — en Alt 2 no se usa esta feature; la rama `sdd/issue-<N>` se crea determinísticamente por el workflow antes de invocar la action
 3. Comentarios persistentes en issues/PRs (`use_sticky_comment`)
 4. Permisos de escritura al repo (`contents: write`)
 5. Tracking de progreso (`track_progress: true`)

--- a/.specs/10-feature/design.md
+++ b/.specs/10-feature/design.md
@@ -3,7 +3,7 @@
 ## Issue: #10 — Spike: adoptar spec driven development
 ## Version: v1.0
 ## Date: 2026-04-12
-## Status: Draft
+## Status: Revised
 
 ---
 
@@ -63,7 +63,7 @@ El workflow SDD se implementa como un sistema de orquestación agéntica sobre G
 | **Ejecución IA** | `claude-code-action@v1` | Corre Claude como agente con acceso a herramientas de repo y Git |
 | **Contexto** | `CLAUDE.md`, `docs/`, `ADR-001` | Instrucciones y restricciones que guían las decisiones del agente |
 | **Specs** | `.specs/<N>-feature/*.md` | Artefactos versionados de cada fase (requirements, design, tasks) |
-| **Aislamiento** | Rama `sdd/issue-<N>-<date>` | Cada ciclo SDD opera en su propia rama; sin contaminar `main` |
+| **Aislamiento** | Rama `sdd/issue-<N>` (determinística) + Draft PR | Cada ciclo SDD opera en su propia rama; las correcciones se centralizan en el PR sin crear ramas adicionales |
 | **Aprobación** | Comentarios en Issue (`@claude-approve-*`) | Compuertas explícitas controladas por el product owner |
 | **Entrega** | Pull Request | Artefacto final de la fase de implementación; merge manual |
 
@@ -222,21 +222,26 @@ sequenceDiagram
 
 ---
 
-### DT-003 — Una rama por ciclo SDD
+### DT-003 — Una rama determinística por ciclo SDD con Draft PR
 
-**Decisión:** Cada ciclo SDD opera en una rama dedicada con prefijo `sdd/issue-<N>-<date>`. Los specs (`.md`) y el código de implementación conviven en la misma rama.
+**Decisión:** Cada ciclo SDD opera en una rama con nombre fijo `sdd/issue-<N>` (sin timestamp). Las tres fases (requirements, design, implement) conviven en la misma rama. Un Draft PR se abre automáticamente al finalizar la fase de requirements y actúa como centro de colaboración para correcciones.
 
 **Alternativas consideradas:**
-- Specs en `main` directamente (contamina el historial de main con commits de documentación)
-- Rama separada para specs y otra para código (overhead, complicaría el merge)
-- Tags de Git en lugar de ramas (no permite commits incrementales durante el ciclo)
+- `branch_prefix: "sdd/"` con timestamp en cada fase (implementación original) — crea una rama por fase, artefactos anteriores no disponibles sin merge previo
+- Merge automático a `main` entre fases — specs llegan a `main` sin revisión formal
+- Rama determinística sin Draft PR — correcciones via `@claude` en el issue crean ramas nuevas
 
-**Justificación:** Una sola rama por ciclo garantiza:
-1. **Trazabilidad:** `git log sdd/issue-10-*` muestra el ciclo completo
-2. **Aislamiento:** `main` solo recibe código aprobado via PR
-3. **Compatibilidad:** `claude-code-action` ya implementa `branch_prefix: "sdd/"` en `sdd-feature.yml`
+**Justificación:** El modelo Draft PR resuelve todos los escenarios de corrección identificados:
+1. **Una sola rama por ciclo:** `git log sdd/issue-<N>` muestra el ciclo completo (requirements → design → impl)
+2. **Sin dependencia de merges intermedios:** `sdd-design` e `sdd-implement` hacen checkout de `sdd/issue-<N>` y tienen acceso a todos los artefactos anteriores sin necesidad de PR mergeados
+3. **Correcciones en contexto PR:** `@claude` en el Draft PR usa `claude.yml` en contexto PR, que pushea a la rama del PR (sin crear nueva rama) — resuelve escenarios S-02, S-04, S-06
+4. **Estado visible:** el Draft PR refleja el estado del ciclo (Draft = en revisión de specs, Ready = listo para code review)
 
-**Consecuencia:** El PR final contiene tanto los archivos `.specs/` como el código implementado. Esto es intencional — los specs son el contrato que justifica el código.
+**Transición de aprobaciones:**
+- Correcciones durante cualquier fase → comenta en el **PR** con `@claude [feedback]`
+- Aprobación de fase → comenta en el **issue** con `@claude-approve-requirements` o `@claude-approve-design`
+
+**Consecuencia:** El PR final contiene tanto los archivos `.specs/` como el código implementado. El historial de commits en `sdd/issue-<N>` refleja el ciclo completo incluyendo correcciones iterativas.
 
 ---
 
@@ -320,7 +325,7 @@ CLAUDE.md                         ❌ no existe — debe crearse
 | `CLAUDE.md` | **Crear** | Instrucciones globales del agente: stack, convenciones, formato de specs, restricciones | Alta |
 | `docs/sdd-workflow-guide.md` | **Crear** | Guía de uso del workflow SDD para el product owner (cómo crear un issue, comandos disponibles, qué esperar en cada fase) | Alta |
 | `.specs/10-feature/tasks.md` | **Crear** (fase impl.) | Lista de tareas de implementación, generada automáticamente cuando se apruebe este design | Media |
-| `sdd-feature.yml` | **Sin cambio** | Ya implementa los 3 jobs correctamente según el requirements.md aprobado | — |
+| `sdd-feature.yml` | **Actualizado** | Implementa Alt 2 (DT-003 rev): rama determinística `sdd/issue-N`, Draft PR automático, checkout de rama existente en fases 2 y 3, `gh pr ready` al finalizar implementación | Alta |
 | `claude-review.yml` | **Actualizar** | Agregar verificación de directorio `.specs/<issue-id>-feature/`; si no existe, el job falla y bloquea el merge (US-05 Scenario 2). Requiere activar branch protection con required status check `spec-review` en `main` | Alta |
 | `claude.yml` | **Sin cambio** | Workflow general no necesita modificación | — |
 | `docs/problem-statement.md` | **Sin cambio** | Solo lectura como contexto del agente | — |

--- a/.specs/10-feature/design.md
+++ b/.specs/10-feature/design.md
@@ -40,7 +40,7 @@ El workflow SDD se implementa como un sistema de orquestación agéntica sobre G
 │         ▼                       ▼                        ▼              │
 │  ┌─────────────┐      ┌──────────────────┐      ┌──────────────────┐   │
 │  │   .specs/   │      │  Git branch      │      │  Issue/PR        │   │
-│  │  <N>-feat/  │      │  sdd/issue-N-*   │      │  Comments        │   │
+│  │  <N>-feat/  │      │  sdd/issue-N     │      │  Comments        │   │
 │  │  *.md files │      │  (aislamiento)   │      │  (feedback loop) │   │
 │  └─────────────┘      └──────────────────┘      └──────────────────┘   │
 └────────────────────────────────────────────────────────────────────────┘
@@ -120,37 +120,40 @@ Cuando un PR intenta implementar una feature sin directorio `.specs/` asociado, 
 ```mermaid
 sequenceDiagram
     actor PO as Product Owner
-    participant GH as GitHub Issues
+    participant GH as GitHub Issues/PR
     participant GA as GitHub Actions
     participant CCA as claude-code-action
     participant Claude as Claude API (sonnet-4-6)
     participant Repo as Git Repository
 
     PO->>GH: Crea issue con descripción y criterios
-    GH->>GA: evento: issues.opened
+    GH->>GA: evento: issues.opened / issues.assigned
+    GA->>Repo: git checkout -b sdd/issue-N (rama determinística)
     GA->>CCA: job sdd-requirements (prompt: generar requirements.md)
     CCA->>Claude: contexto + instrucciones + issue body
     Claude-->>CCA: plan de ejecución
-    CCA->>Repo: git checkout -b sdd/issue-N-<date>
     CCA->>Repo: mkdir .specs/N-feature/
     CCA->>Repo: write requirements.md
     CCA->>Repo: git commit && git push
     CCA->>GH: comenta "✅ requirements.md generado..."
+    GA->>GH: abre Draft PR (sdd/issue-N → main)
     GH-->>PO: notificación
 
-    PO->>PO: revisa requirements.md en rama sdd/issue-N-*
+    PO->>PO: revisa requirements.md en Draft PR
     alt feedback necesario
-        PO->>GH: comenta con correcciones (sin @claude-approve)
-        GH->>GA: evento: issue_comment
-        GA->>CCA: job sdd-requirements (actualizar doc)
+        PO->>GH: comenta en PR con @claude + correcciones
+        GH->>GA: evento: pull_request_review_comment
+        GA->>CCA: claude.yml (contexto PR, rama sdd/issue-N)
         CCA->>Repo: edita requirements.md (Revised)
         CCA->>Repo: git commit && git push
         CCA->>GH: comenta "✅ requirements.md actualizado..."
     end
 
-    PO->>GH: comenta "@claude-approve-requirements"
+    PO->>GH: comenta en issue "@claude-approve-requirements"
     GH->>GA: evento: issue_comment (contiene @claude-approve-requirements)
+    GA->>Repo: git checkout sdd/issue-N (existente)
     GA->>CCA: job sdd-design (prompt: generar design.md)
+    CCA->>Repo: actualiza requirements.md → Status: Approved
     CCA->>Claude: requirements.md + ADR-001 + instrucciones
     Claude-->>CCA: diseño técnico
     CCA->>Repo: write design.md
@@ -158,25 +161,29 @@ sequenceDiagram
     CCA->>GH: comenta "✅ design.md generado..."
     GH-->>PO: notificación
 
-    PO->>PO: revisa design.md
+    PO->>PO: revisa design.md en Draft PR
     alt feedback necesario
-        PO->>GH: comenta con correcciones
-        GA->>CCA: actualiza design.md
+        PO->>GH: comenta en PR con @claude + correcciones
+        GA->>CCA: claude.yml (contexto PR, rama sdd/issue-N)
+        CCA->>Repo: edita design.md (Revised)
         CCA->>Repo: git commit && git push
     end
 
-    PO->>GH: comenta "@claude-approve-design"
+    PO->>GH: comenta en issue "@claude-approve-design"
     GH->>GA: evento: issue_comment (contiene @claude-approve-design)
+    GA->>Repo: git checkout sdd/issue-N (existente)
     GA->>CCA: job sdd-implement (prompt: implementar)
+    CCA->>Repo: actualiza design.md → Status: Approved
     CCA->>Claude: requirements.md + design.md + codebase
     Claude-->>CCA: plan de implementación
     CCA->>Repo: write tasks.md
     CCA->>Repo: implementa código (múltiples commits)
-    CCA->>GH: abre Pull Request → issue #N
-    GH-->>PO: notificación PR listo
+    CCA->>GH: comenta "✅ implementación completa, PR listo para review"
+    GA->>GH: convierte Draft PR → Ready for Review (gh pr ready)
+    GH-->>PO: notificación PR listo para code review
 
     PO->>GH: revisa PR, hace merge manualmente
-    GH->>Repo: merge sdd/issue-N-* → main
+    GH->>Repo: merge sdd/issue-N → main
 ```
 
 ---
@@ -384,7 +391,7 @@ Al trabajar en un issue con ciclo SDD:
 | Riesgo | Mitigación |
 |---|---|
 | Cualquier colaborador puede activar el workflow con `@claude` | GitHub Actions solo ejecuta en comentarios de issues/PRs del repositorio; requiere acceso de escritura |
-| El agente podría hacer push a ramas críticas | `branch_prefix: "sdd/"` limita las ramas creadas; `main` requiere PR + aprobación manual |
+| El agente podría hacer push a ramas críticas | Rama `sdd/issue-N` creada determinísticamente por el workflow (no por el agente); `main` requiere PR + aprobación manual |
 | Prompt injection en el cuerpo del issue | `claude-code-action` sanitiza el contexto; el agente opera con herramientas limitadas (`--allowedTools`) |
 | Exposición de secretos en logs | `CLAUDE_CODE_OAUTH_TOKEN` y `GIT_HUB_PAT` son GitHub Secrets; no aparecen en logs |
 | Ejecución de código arbitrario via specs | Las herramientas permitidas en `sdd-feature.yml` están acotadas: `Bash(git *), Read, Write, Edit` |

--- a/.specs/10-feature/requirements.md
+++ b/.specs/10-feature/requirements.md
@@ -52,8 +52,8 @@ THEN se crea el archivo en `.specs/<issue-id>-feature/requirements.md`
 **Scenario 2 — requirements.md rechazado por el product owner**
 ```
 GIVEN que el agente ha generado un requirements.md
-  AND el product owner revisa el documento y detecta ambigüedades o errores
-WHEN el product owner comenta en el issue con correcciones
+  AND el product owner revisa el documento en el Draft PR y detecta ambigüedades o errores
+WHEN el product owner comenta en el PR del ciclo SDD con @claude + correcciones
 THEN el agente actualiza el requirements.md incorporando el feedback
   AND genera una nueva versión sin crear un archivo duplicado
   AND el status del archivo pasa a "Revised"
@@ -258,30 +258,35 @@ THEN el agente actualiza el documento según el feedback
 ## Flujo de trabajo agéntico (resumen)
 
 ```
-Issue creado (GitHub)
+Issue creado/asignado (GitHub)
        │
        ▼
-@claude mencionado
+GA crea rama sdd/issue-N + Agente genera requirements.md
+       │
+       ├──► Draft PR abierto automáticamente (sdd/issue-N → main)
        │
        ▼
-Agente genera requirements.md ──► Product owner revisa
-       │                                    │
-       │◄───────────────── feedback ────────┘
+Product owner revisa en Draft PR
+       │                    │
+       │◄── @claude en PR ──┘  (correcciones)
        │
-  @claude-approve-requirements
-       │
-       ▼
-Agente genera design.md ──► Product owner revisa
-       │                              │
-       │◄─────────── feedback ────────┘
-       │
-  @claude-approve-design
+  @claude-approve-requirements (en issue)
        │
        ▼
-Agente implementa código
+Agente marca requirements Approved + genera design.md
        │
        ▼
-Agente abre PR ──► Product owner hace merge
+Product owner revisa en Draft PR
+       │                    │
+       │◄── @claude en PR ──┘  (correcciones)
+       │
+  @claude-approve-design (en issue)
+       │
+       ▼
+Agente marca design Approved + implementa código
+       │
+       ▼
+Draft PR → Ready for Review ──► Product owner hace merge
 ```
 
 ---

--- a/.specs/10-feature/requirements.md
+++ b/.specs/10-feature/requirements.md
@@ -200,11 +200,12 @@ THEN el agente bloquea el merge y solicita la creación de las specs
 **Scenario 1 — Flujo completo sin interrupciones**
 ```
 GIVEN que el product owner crea un issue con descripción y criterios
-WHEN el product owner menciona "@claude" en el issue
-THEN el agente genera requirements.md y espera aprobación
-  AND al recibir "@claude-approve-requirements", genera design.md y espera aprobación
-  AND al recibir "@claude-approve-design", inicia la implementación
-  AND al completar la implementación, abre un PR con referencia al issue
+WHEN el issue es creado o asignado en GitHub
+THEN el agente genera requirements.md en rama sdd/issue-N y espera aprobación
+  AND un Draft PR se abre automáticamente (sdd/issue-N → main) al finalizar requirements
+  AND al recibir "@claude-approve-requirements" en el issue, genera design.md y espera aprobación
+  AND al recibir "@claude-approve-design" en el issue, inicia la implementación
+  AND al completar la implementación, el Draft PR pasa a Ready for Review
   AND el product owner revisa el PR y hace merge manualmente
 ```
 

--- a/.specs/10-feature/tasks.md
+++ b/.specs/10-feature/tasks.md
@@ -1,0 +1,194 @@
+# Tasks — Spec Driven Development (SDD) Workflow
+
+## Issue: #10 — Spike: adoptar spec driven development
+## Version: v1.0
+## Date: 2026-04-12
+## Status: In Progress
+
+---
+
+## Resumen de implementación
+
+Este archivo documenta las tareas de implementación del workflow SDD Alt 2 (DT-003), derivadas de `.specs/10-feature/design.md` aprobado.
+
+---
+
+## Tareas completadas
+
+### [x] T-01 — Implementar `sdd-feature.yml` con Alt 2 (DT-003)
+
+**Descripción:** Crear el workflow de GitHub Actions con tres jobs (`sdd-requirements`, `sdd-design`, `sdd-implement`) usando rama determinística `sdd/issue-<N>` y Draft PR automático.
+
+**Artefactos:**
+- `.github/workflows/sdd-feature.yml` ✅
+
+**Criterios:**
+- [x] Rama determinística `sdd/issue-N` (sin timestamp) con idempotencia via `git ls-remote --exit-code`
+- [x] Draft PR automático al finalizar `sdd-requirements` con verificación `PR_EXISTS`
+- [x] `sdd-design` e `sdd-implement` hacen checkout de `sdd/issue-N` existente
+- [x] `branch_prefix` eliminado en los tres jobs
+- [x] `--allowedTools` explícitos en los tres jobs
+- [x] Paso 0 en `sdd-design`: marcar `requirements.md` como Approved
+- [x] Paso 0 en `sdd-implement`: marcar `design.md` como Approved
+- [x] Conversión Draft PR → Ready for Review al finalizar `sdd-implement`
+- [x] Mensajes de commit referencian `#N`
+- [x] Instrucción "no crees una rama nueva" en los tres prompts
+
+**Commits:** `8cac0d5`, `ff05362`, `81f3c0b`
+
+---
+
+### [x] T-02 — Actualizar `.specs/10-feature/design.md`
+
+**Descripción:** Actualizar el design.md para reflejar la implementación Alt 2 / DT-003.
+
+**Criterios:**
+- [x] DT-003 actualizado con justificación del modelo Draft PR
+- [x] Diagrama ASCII actualizado: `sdd/issue-N` sin wildcard
+- [x] Diagrama Mermaid reescrito para reflejar Alt 2
+- [x] Consideraciones de seguridad: rama creada por workflow, no por agente
+- [x] DT-005: aclaración de que `branch_prefix` no se usa en Alt 2
+
+**Commits:** `8cac0d5`, `ff05362`, `81f3c0b`
+
+---
+
+### [x] T-03 — Actualizar `.specs/10-feature/requirements.md`
+
+**Descripción:** Alinear requirements.md con la implementación real.
+
+**Criterios:**
+- [x] US-01 S2: feedback via Draft PR, no issue
+- [x] US-06 S1: trigger es `issues.opened/assigned`, Draft PR automático, `gh pr ready` al finalizar
+- [x] Flujo de trabajo agéntico (resumen) refleja el modelo Alt 2
+
+**Commits:** `ff05362`, `81f3c0b`
+
+---
+
+### [x] T-04 — Crear `CLAUDE.md`
+
+**Descripción:** Instrucciones persistentes para el agente: stack, convenciones, restricciones, flujo SDD.
+
+**Artefactos:**
+- `CLAUDE.md` ✅
+
+**Criterios:**
+- [x] Stack tecnológico documentado
+- [x] Flujo SDD documentado (comandos, fases, orden de lectura)
+- [x] Convenciones de commits
+- [x] Convenciones de código (GAS)
+- [x] Restricciones del agente
+- [x] Archivos de solo lectura identificados
+
+---
+
+### [x] T-05 — Crear `docs/sdd-workflow-guide.md`
+
+**Descripción:** Guía de uso del workflow SDD para el product owner.
+
+**Artefactos:**
+- `docs/sdd-workflow-guide.md` ✅
+
+**Criterios:**
+- [x] Flujo completo paso a paso documentado
+- [x] Referencia rápida de comandos
+- [x] Ubicación de artefactos
+- [x] Reglas importantes
+- [x] Resolución de problemas comunes
+
+---
+
+## Tareas pendientes (trabajo futuro)
+
+### [ ] T-06 — Actualizar `claude-review.yml` (US-05 S2)
+
+**Descripción:** Agregar verificación de `.specs/<issue-id>-feature/` y bloqueo de merge si no existe.
+
+**Prioridad:** Alta
+
+**Bloqueante:** Requiere permisos de workflow en el token (`workflows` scope). El GitHub App de `claude-code-action` no tiene este permiso por defecto.
+
+**Criterios:**
+- [ ] Job `spec-review` extrae número de issue del título/body del PR
+- [ ] Verifica existencia de `.specs/<issue-id>-feature/`
+- [ ] Si no existe: comentario bloqueante en PR + job falla (exit code != 0)
+- [ ] Branch protection en `main` requiere `spec-review` como status check
+
+**Activación:** Configurar branch protection rule en GitHub → Settings → Branches → `main` → Require status checks → `spec-review`
+
+---
+
+### [ ] T-07 — Agregar `Bash(gh pr comment:*)` en `sdd-implement` (US-03 S2)
+
+**Descripción:** Habilitar al agente para documentar gaps de design en comentarios del PR (no solo del issue).
+
+**Prioridad:** Alta
+
+**Bloqueante:** Requiere permisos de workflow.
+
+**Cambios requeridos en `sdd-feature.yml`:**
+```yaml
+# job sdd-implement, claude_args:
+--allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Read,Write,Edit,Bash(gh issue comment:*),Bash(gh pr comment:*)"
+```
+```
+# Agregar al prompt de sdd-implement:
+Si durante la implementación detectas que el design.md tiene un gap o error que impide
+implementar un módulo como fue diseñado:
+1. Documenta el gap con `gh pr comment --body "..."` en el PR del ciclo SDD
+2. No continúes con la implementación de ese módulo hasta recibir confirmación (US-03 Scenario 2)
+```
+
+---
+
+### [ ] T-08 — Cubrir US-04 S1/S2 en prompts de `sdd-implement`
+
+**Descripción:** Agregar instrucciones en el prompt de `sdd-implement` para referenciar IDs de scenario en tests y bloquear push si tests existentes fallan.
+
+**Prioridad:** Media
+
+**Bloqueante:** Requiere permisos de workflow.
+
+**Cambios en prompt de `sdd-implement`:**
+```
+- Los nombres de los tests deben referenciar el ID del scenario (ej. "US-01 Scenario 1")
+- Antes de hacer commit, ejecuta los tests existentes; si alguno falla, repórtalo sin hacer push
+```
+
+---
+
+### [ ] T-09 — Actualizar estado del PR body en `sdd-design` y `sdd-implement`
+
+**Descripción:** Actualizar el cuerpo del Draft PR para reflejar el estado actual del ciclo (REQUIREMENTS IN REVIEW → DESIGN IN REVIEW → IMPLEMENTATION IN PROGRESS).
+
+**Prioridad:** Baja
+
+**Bloqueante:** Requiere permisos de workflow.
+
+---
+
+### [ ] T-10 — Homogenizar `fetch-depth` en fases 2 y 3
+
+**Descripción:** Cambiar `fetch-depth: 1` a `fetch-depth: 0` en `sdd-design` y `sdd-implement` para consistencia con `sdd-requirements`.
+
+**Prioridad:** Baja
+
+**Bloqueante:** Requiere permisos de workflow.
+
+---
+
+## Trazabilidad
+
+| Tarea | User Story | Status |
+|---|---|---|
+| T-01 | US-01 S1, US-06 S1/S2, DT-003 | ✅ Completada |
+| T-02 | DT-003, DT-005 | ✅ Completada |
+| T-03 | US-01 S2, US-06 S1 | ✅ Completada |
+| T-04 | DT-006 | ✅ Completada |
+| T-05 | US-06 S1 (guía de uso) | ✅ Completada |
+| T-06 | US-05 S2 | ⏳ Pendiente (requiere permisos workflow) |
+| T-07 | US-03 S2 | ⏳ Pendiente (requiere permisos workflow) |
+| T-08 | US-04 S1/S2 | ⏳ Pendiente (requiere permisos workflow) |
+| T-09 | — | ⏳ Pendiente (requiere permisos workflow) |
+| T-10 | — | ⏳ Pendiente (requiere permisos workflow) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — Instrucciones para el agente Claude
+
+## Contexto del proyecto
+
+Ver `docs/problem-statement.md` para el problema de negocio.
+Ver `docs/decisions/ADR-001-stack-tecnologico.md` para el stack tecnológico.
+
+**Resumen:** Finanzas C&C es un pipeline que consolida gastos de 2 usuarios desde Gmail (BCP, Interbank, BBVA, Scotiabank, Yape/Plin) hacia Google Sheets. Sin costo de infraestructura. Sin app móvil en v1.
+
+---
+
+## Stack tecnológico
+
+| Componente | Tecnología |
+|---|---|
+| Implementación | Google Apps Script (JavaScript) |
+| Almacenamiento | Google Sheets |
+| Ingesta | Gmail API (nativa de Apps Script) |
+| Categorización IA | Claude API (claude-haiku-4-5) |
+| Modelo de workflow | claude-sonnet-4-6 (o superior) |
+| CI/CD | GitHub Actions + claude-code-action@v1 |
+
+**Restricción crítica:** No instalar dependencias externas. No hay `package.json`. No hay Node.js runtime en producción.
+
+---
+
+## Workflow SDD (Spec Driven Development)
+
+Al trabajar en un issue con ciclo SDD, el orden de lectura es obligatorio:
+
+1. Lee `.specs/<issue-id>-feature/requirements.md` antes de cualquier acción
+2. Lee `.specs/<issue-id>-feature/design.md` antes de implementar
+3. No implementes nada que no esté especificado en el `design.md` aprobado
+4. Si detectas un gap en el design durante la implementación:
+   - Documéntalo con `gh pr comment` en el PR del ciclo SDD
+   - No continúes con la implementación hasta recibir confirmación explícita
+
+### Estructura de specs esperada
+
+```
+.specs/
+└── <issue-id>-feature/
+    ├── requirements.md    # Status: Draft → Revised → Approved
+    ├── design.md          # Status: Draft → Revised → Approved
+    └── tasks.md           # Generado en fase de implementación
+```
+
+### Comandos del workflow
+
+| Comando | Dónde | Acción |
+|---|---|---|
+| `@claude [feedback]` | Comentario en el **PR** (Draft PR del ciclo) | Corrección en la fase actual, sin avanzar de fase |
+| `@claude-approve-requirements` | Comentario en el **issue** | Avanza a fase de design |
+| `@claude-approve-design` | Comentario en el **issue** | Avanza a fase de implementación |
+
+---
+
+## Convenciones de commits
+
+- **Prefijo obligatorio:** `feat` | `fix` | `docs` | `chore` | `test`
+- **Referencia al issue:** `#N` al final del mensaje
+- **Formato:** `<tipo>: <descripción concisa> for issue #N`
+- **Ejemplo:** `feat: add BCP email parser for issue #7`
+
+---
+
+## Convenciones de código (Google Apps Script)
+
+- Idioma del código: inglés (variables, funciones, comentarios técnicos)
+- Idioma de specs y docs: español
+- Nombres de función: camelCase
+- Constantes: UPPER_SNAKE_CASE
+- Cada parser de banco en archivo separado: `src/parsers/<banco>Parser.js`
+- Tests en: `src/tests/<módulo>Test.js`
+
+---
+
+## Restricciones del agente
+
+- No crear ramas adicionales a la asignada por el workflow
+- No hacer push a `main` directamente
+- No modificar `.github/workflows/` sin instrucción explícita
+- No instalar dependencias externas (sin `npm install`, sin `pip install`)
+- No avanzar de fase sin aprobación explícita del product owner
+- No hacer push si tests existentes fallan — reportar primero
+
+---
+
+## Archivos de solo lectura (no modificar sin instrucción explícita)
+
+- `docs/problem-statement.md`
+- `docs/decisions/ADR-001-stack-tecnologico.md`
+- `.specs/<N>-feature/requirements.md` (solo actualizar `Status:` cuando se aprueba)
+- `.specs/<N>-feature/design.md` (solo actualizar `Status:` cuando se aprueba)

--- a/docs/sdd-workflow-guide.md
+++ b/docs/sdd-workflow-guide.md
@@ -1,0 +1,161 @@
+# Guía de uso — Workflow SDD (Spec Driven Development)
+
+## Versión: v1.0
+## Fecha: 2026-04-12
+
+---
+
+## ¿Qué es el workflow SDD?
+
+El workflow SDD permite al product owner dirigir el desarrollo de una nueva feature a través de tres fases estructuradas, con un agente de IA (Claude) ejecutando cada fase y esperando aprobación explícita antes de avanzar.
+
+```
+Issue → Requirements → Design → Implementación → PR listo para merge
+```
+
+Cada fase produce un artefacto en `.specs/<issue-id>-feature/` que puede revisarse directamente en GitHub.
+
+---
+
+## Requisitos previos
+
+- Acceso de escritura al repositorio `rcastillejo/exprense-tracker`
+- Capacidad de crear issues y comentar en GitHub
+
+---
+
+## Flujo completo paso a paso
+
+### Fase 1 — Crear el issue
+
+1. Ve a **Issues → New issue** en el repositorio
+2. Escribe una descripción clara del problema o feature que necesitas
+3. Incluye criterios de aceptación en lenguaje natural (qué debe hacer, qué no debe hacer)
+4. Asigna el issue a cualquier colaborador (o a ti mismo) para activar el workflow
+5. El agente generará automáticamente `.specs/<N>-feature/requirements.md` y abrirá un **Draft PR**
+
+**Resultado esperado:** Un Draft PR aparece en el repositorio con el archivo `requirements.md` generado.
+
+---
+
+### Fase 1 — Revisar requirements.md
+
+1. Abre el Draft PR (lo encontrarás en **Pull requests** con el título `feat: SDD cycle for issue #N`)
+2. Revisa el archivo `.specs/<N>-feature/requirements.md` en la pestaña **Files changed**
+3. Verifica que las user stories y criterios GIVEN/WHEN/THEN reflejen lo que necesitas
+
+**Si necesitas correcciones:**
+```
+@claude [descripción de las correcciones]
+```
+Comenta esto **en el PR** (no en el issue). El agente actualizará el documento y notificará cuando esté listo.
+
+**Si el documento está correcto:**
+Avanza a la siguiente fase con el comando de aprobación (ver abajo).
+
+---
+
+### Aprobación de Requirements → Design
+
+Comenta esto **en el issue** (no en el PR):
+```
+@claude-approve-requirements
+```
+
+El agente:
+1. Marca `requirements.md` como `Approved`
+2. Genera `.specs/<N>-feature/design.md` con arquitectura y decisiones técnicas
+3. Notifica en el issue que el diseño está listo
+
+---
+
+### Fase 2 — Revisar design.md
+
+1. Abre el mismo Draft PR
+2. Revisa el archivo `.specs/<N>-feature/design.md`
+3. Verifica la arquitectura propuesta, decisiones técnicas e impacto en el codebase
+
+**Si necesitas correcciones:**
+```
+@claude [descripción de las correcciones al design]
+```
+Comenta esto **en el PR**.
+
+**Si el documento está correcto:**
+Avanza a la fase de implementación.
+
+---
+
+### Aprobación de Design → Implementación
+
+Comenta esto **en el issue** (no en el PR):
+```
+@claude-approve-design
+```
+
+El agente:
+1. Marca `design.md` como `Approved`
+2. Genera `.specs/<N>-feature/tasks.md` con el plan de implementación
+3. Implementa el código según el design aprobado
+4. Convierte el Draft PR a **Ready for Review**
+5. Notifica cuando la implementación está completa
+
+---
+
+### Fase 3 — Revisar e implementación
+
+1. El PR ya no es Draft — aparece como listo para review
+2. Revisa los cambios en la pestaña **Files changed**
+3. Verifica que el código cumple con los criterios del `requirements.md`
+4. Si todo está correcto, haz **Merge** manualmente
+
+---
+
+## Referencia rápida de comandos
+
+| Comando | Dónde escribirlo | Efecto |
+|---|---|---|
+| `@claude [feedback]` | Comentario en el **PR** | Corrige el artefacto actual sin avanzar de fase |
+| `@claude-approve-requirements` | Comentario en el **issue** | Aprueba requirements y genera design |
+| `@claude-approve-design` | Comentario en el **issue** | Aprueba design e inicia implementación |
+
+---
+
+## Dónde encontrar los artefactos
+
+| Artefacto | Ubicación en el repo |
+|---|---|
+| Requirements | `.specs/<N>-feature/requirements.md` |
+| Design técnico | `.specs/<N>-feature/design.md` |
+| Plan de tareas | `.specs/<N>-feature/tasks.md` |
+| Código implementado | Según estructura definida en `design.md` |
+
+---
+
+## Reglas importantes
+
+1. **Los comandos de aprobación van en el issue**, no en el PR
+2. **Las correcciones van en el PR**, no en el issue — esto asegura que el agente tenga contexto del documento actual
+3. **El agente no avanza automáticamente** — toda transición requiere un comando explícito tuyo
+4. **No merges manuales de la rama** `sdd/issue-N` — el workflow gestiona todos los commits; solo haces merge del PR final cuando todo esté revisado
+
+---
+
+## Resolución de problemas
+
+### El Draft PR no aparece después de crear el issue
+
+- Verifica que el issue esté **asignado** a un colaborador (el trigger es `issues.assigned`)
+- Revisa los logs en **Actions** → **SDD Feature Workflow** para ver si hay errores
+
+### El agente no responde a mi comentario en el PR
+
+- Asegúrate de que el comentario esté en el **PR correcto** (el que tiene la rama `sdd/issue-N`)
+- Verifica que estás usando `@claude` (no `@Claude` ni otra variación)
+- Revisa los logs en **Actions** → busca el run más reciente
+
+### Quiero cancelar el ciclo SDD
+
+- Cierra el Draft PR manualmente
+- Cierra el issue o elimina el label/asignación
+- La rama `sdd/issue-N` puede eliminarse manualmente desde GitHub si lo deseas


### PR DESCRIPTION
Implementa la Alternativa 2 del workflow SDD: rama determinística `sdd/issue-N` + Draft PR automático.

## Cambios

- `sdd-requirements`: crea rama determinística `sdd/issue-N` (sin timestamp), abre Draft PR automáticamente
- `sdd-design`: checkout de `sdd/issue-N` existente, marca requirements.md como Approved
- `sdd-implement`: checkout de `sdd/issue-N`, marca design.md como Approved, convierte Draft PR → Ready
- Correcciones en cualquier fase: @claude en el PR (sin crear rama nueva)
- DT-003 actualizado en design.md

Resuelve #10

Generated with [Claude Code](https://claude.ai/code)